### PR TITLE
Make variograms picklable - unittest fix

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,7 @@ Changelog
 Version 0.2.8
 =============
 
+- [Variogram] is now ``pickle.dump()``-able, by removing ``lambda`` usage (thanks to @redhog!)
 - [Variogram] now raises a `Warning` if all input values are the same
 - [DOCS] Tutorial added and Dockerfile finalized
 - [Variogram] `normalize` default value changed to `normalize=False`

--- a/skgstat/Kriging.py
+++ b/skgstat/Kriging.py
@@ -105,7 +105,7 @@ class OrdinaryKriging:
         self.perf = perf
 
         # copy the distance function from the Variogram
-        self.dist = self.V.dist_function
+        self.dist = self.V._dist_func_wrapper
         params = self.V.describe()
         self.range = params['effective_range']
         self.nugget = params['nugget']

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -594,6 +594,12 @@ class Variogram(object):
     def dist_function(self):
         return self._dist_func
 
+    def _dist_func_wrapper(self, x):
+        if callable(self._dist_func):
+            return self._dist_func(x)
+        else:
+            return pdist(X=x, metric=self._dist_func)
+    
     @dist_function.setter
     def dist_function(self, func):
         self.set_dist_function(func=func)
@@ -626,7 +632,7 @@ class Variogram(object):
                 raise NotImplementedError
             else:
                 # if not ranks, it has to be a scipy metric
-                self._dist_func = lambda x: pdist(X=x, metric=func)
+                self._dist_func = func
 
         elif callable(func):
             self._dist_func = func
@@ -1014,7 +1020,7 @@ class Variogram(object):
         else:
             _x = self._X
         # else calculate the distances
-        self._dist = self._dist_func(_x)
+        self._dist = self._dist_func_wrapper(_x)
 
     def _calc_diff(self, force=False):
         """Calculates the pairwise differences


### PR DESCRIPTION
@redhog it was this line:
https://github.com/mmaelicke/scikit-gstat/blob/0257d4ec21f5d54fb5f08092b48c964d4192be3a/skgstat/Kriging.py#L108

where the `Krignig` class was using the `Variogram` distance function. Now, the unittests work locally, and as soon as the CI also runs without error, I will merge this PR.
I had to open a new one, as I am not sure if I could have pushed something directly into your PR, thus I copied it.