### PR TITLE
Angle math bugfix

### DIFF
--- a/skgstat/DirectionalVariogram.py
+++ b/skgstat/DirectionalVariogram.py
@@ -641,6 +641,9 @@ class DirectionalVariogram(Variogram):
         # get the maximum x coordinate in the current representation
         xmax = np.max(local_ref[:, 0])
 
+        if h >= xmax:
+            return self._compass(local_ref)
+
         # build the figure
         poly = Polygon([
             (0, 0),

--- a/skgstat/DirectionalVariogram.py
+++ b/skgstat/DirectionalVariogram.py
@@ -757,7 +757,7 @@ class DirectionalVariogram(Variogram):
         xmax = np.max(local_ref[:,0])
 
         # calculate the radius and y coordinates
-        r = xmax / a
+        r = xmax / np.cos(a)
         y = r * np.sin(a)
 
         # build and return the figure

--- a/skgstat/tests/DirectionalVariogram.py
+++ b/skgstat/tests/DirectionalVariogram.py
@@ -17,7 +17,7 @@ class TestDirectionalVariogramInstantiation(unittest.TestCase):
     def test_standard_settings(self):
         DV = DirectionalVariogram(self.c, self.v, normalize=True)
 
-        for x, y in zip(DV.parameters, [406., 2145., 0]):
+        for x, y in zip(DV.parameters, [407.467, 2138.098, 0]):
             self.assertAlmostEqual(x, y, places=0)
 
     def test_azimuth(self):
@@ -38,7 +38,7 @@ class TestDirectionalVariogramInstantiation(unittest.TestCase):
     def test_tolerance(self):
         DV = DirectionalVariogram(self.c, self.v, tolerance=15, normalize=True)
 
-        for x, y in zip(DV.parameters, [32.474, 2016.601, 0]):
+        for x, y in zip(DV.parameters, [26.342, 1880.015, 0]):
             self.assertAlmostEqual(x, y, places=3)
 
     def test_invalid_tolerance(self):
@@ -53,7 +53,7 @@ class TestDirectionalVariogramInstantiation(unittest.TestCase):
     def test_bandwidth(self):
         DV = DirectionalVariogram(self.c, self.v, bandwidth=12, normalize=True)
 
-        for x, y in zip(DV.parameters, [435.733, 2746.608, 0]):
+        for x, y in zip(DV.parameters, [435.733, 2715.865, 0]):
             self.assertAlmostEqual(x, y, places=3)
 
     def test_invalid_model(self):


### PR DESCRIPTION
Fixed two issues

* For compass search area, the r is now correctly calculated as `r = xmax / np.cos(a)`, see https://github.com/mmaelicke/scikit-gstat/issues/51
* For triangle search area, the shape is now correctly calculated when h > xmax (by generating the same shape compass would)