### PR TITLE
Multiple plotting backends

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 omit = 
     skgstat/tests/*
+    skgstat/plotting/*
     docs/*
     setup.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ docs/savefig
 notebooks
 .vscode
 container
+
+# project specific
+Playground.ipynb

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 0.3.1
+=============
+
+- [Variogram] - internal distance calculations were refactored, to speed things up
+- [Kriging] - internal distance calculations were refactored, to speed things up
+
 Version 0.3.0
 =============
 

--- a/requirements.unittest.3.5.txt
+++ b/requirements.unittest.3.5.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
+pytest-depends
 pykrige
 gstools==1.1.*

--- a/requirements.unittest.3.5.txt
+++ b/requirements.unittest.3.5.txt
@@ -3,3 +3,4 @@ pytest-cov
 pytest-depends
 pykrige
 gstools==1.1.*
+plotly

--- a/requirements.unittest.3.6.txt
+++ b/requirements.unittest.3.6.txt
@@ -3,3 +3,4 @@ pytest-cov
 pytest-depends
 pykrige
 gstools
+plotly

--- a/requirements.unittest.3.6.txt
+++ b/requirements.unittest.3.6.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
+pytest-depends
 pykrige
 gstools

--- a/requirements.unittest.3.7.txt
+++ b/requirements.unittest.3.7.txt
@@ -3,3 +3,4 @@ pytest-cov
 pytest-depends
 pykrige
 gstools
+plotly

--- a/requirements.unittest.3.7.txt
+++ b/requirements.unittest.3.7.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
+pytest-depends
 pykrige
 gstools

--- a/requirements.unittest.3.8.txt
+++ b/requirements.unittest.3.8.txt
@@ -3,3 +3,4 @@ pytest-cov
 pytest-depends
 pykrige
 gstools
+plotly

--- a/requirements.unittest.3.8.txt
+++ b/requirements.unittest.3.8.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-cov
+pytest-depends
 pykrige
 gstools

--- a/skgstat/DirectionalVariogram.py
+++ b/skgstat/DirectionalVariogram.py
@@ -583,7 +583,7 @@ class DirectionalVariogram(Variogram):
         if used_backend == 'matplotlib':
             return plotting.matplotlib_pair_field(self, ax=ax, cmap=cmap, points=points, add_points=add_points, alpha=alpha, **kwargs)
         elif used_backend == 'plotly':
-            raise NotImplementedError        
+            return plotting.plotly_pair_field(self, fig=ax, points=points, add_points=add_points, alpha=alpha, **kwargs)       
 
     def _triangle(self, angles, dists):
         r"""Triangular Search Area

--- a/skgstat/SpaceTimeVariogram.py
+++ b/skgstat/SpaceTimeVariogram.py
@@ -975,9 +975,6 @@ class SpaceTimeVariogram:
         # if force, force a clean preprocessing
         self.preprocessing(force=force)
 
-        # This is not finished
-        return
-
         # load the fitting data
         xx, yy = self.meshbins
         z = self.experimental
@@ -997,10 +994,6 @@ class SpaceTimeVariogram:
         model_args = inspect.getargs(_code_obj).args
         self._model_params = dict()
 
-#        if 'Vx' in model_args:
-#            self._model_params['Vx'] = Vx
-#        if 'Vt' in model_args:
-#            self._model_params['Vt'] = Vt
 
         # fix the sills?
         fix_sills = True    # TODO: Make this a param in __init__
@@ -1022,7 +1015,7 @@ class SpaceTimeVariogram:
             return self._model(lags, Vx, Vt, *args, **self._model_params)
 
         self.cof, self.cov = curve_fit(
-            _model, xdata, ydata, bounds=[0,  np.inf], p0=[1.] * free_args
+            _model, xdata.T, ydata, bounds=[0,  np.inf], p0=[1.] * free_args
         )
 
         return
@@ -1046,9 +1039,12 @@ class SpaceTimeVariogram:
         Vx = self.XMarginal.fitted_model
         Vt = self.TMarginal.fitted_model
 
+        cof = self.cof if self.cof is not None else []
+        params = self._model_params if self._model_params is not None else {}
+
         # define the function
         def model(lags):
-            return func(lags, Vx, Vt, *self.cof, **self._model_params)
+            return func(lags, Vx, Vt, *cof, **params)
 
         return model
 

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -1526,6 +1526,9 @@ class Variogram(object):
         is passed, the hist attribute will be ignored as only the variogram
         will be plotted anyway.
 
+        .. versionchanged:: 0.4.0
+            This plot can be plotted with the plotly plotting backend
+
         Parameters
         ----------
         axes : list, tuple, array, AxesSubplot or None
@@ -1569,6 +1572,9 @@ class Variogram(object):
         This can be used to investigate the distribution of the
         value residuals.
 
+        .. versionchanged:: 0.4.0
+            This plot can be plotted with the plotly plotting backend
+
         Parameters
         ----------
         ax : matplotlib.Axes, plotly.graph_objects.Figure
@@ -1605,6 +1611,9 @@ class Variogram(object):
         location, this would violate the intrinsic hypothesis. This is a
         weaker form of stationarity of second order.
 
+        .. versionchanged:: 0.4.0
+            This plot can be plotted with the plotly plotting backend
+
         Parameters
         ----------
         axes : list
@@ -1616,34 +1625,19 @@ class Variogram(object):
 
         Returns
         -------
-        matplotlib.Figure
+        matplotlib.Figure, plotly.graph_objects.Figure
 
         """
-        N = len(self._X[0])
-        if axes is None:
-            # derive the needed amount of col and row
-            nrow = int(round(np.sqrt(N)))
-            ncol = int(np.ceil(N / nrow))
-            fig, axes = plt.subplots(nrow, ncol, figsize=(ncol * 6 ,nrow * 6))
-        else:
-            if not len(axes) == N:
-                raise ValueError(
-                    'The amount of passed axes does not fit the coordinate' +
-                    ' dimensionality of %d' % N)
-            fig = axes[0].get_figure()
+        # get the backend
+        used_backend = plotting.backend()
 
-        for i in range(N):
-            axes.flatten()[i].plot([_[i] for _ in self._X], self.values, '.r')
-            axes.flatten()[i].set_xlabel('%d-dimension' % (i + 1))
-            axes.flatten()[i].set_ylabel('value')
-
-        # plot the figure and return it
-        plt.tight_layout()
-
-        if show:  # pragma: no cover
-            fig.show()
-
-        return fig
+        if used_backend == 'matplotlib':
+            return plotting.matplotlib_location_trend(self, axes=axes, show=show)
+        elif used_backend == 'plotly':
+            return plotting.plotly_location_trend(self, fig=axes, show=show)
+        
+        # if we reach this line, somethings wrong with plotting backend
+        raise ValueError('The plotting backend has an undefined state.')
 
     def distance_difference_plot(self, ax=None, plot_bins=True, show=True):
         """Raw distance plot

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -1645,6 +1645,9 @@ class Variogram(object):
         Plots all absoulte value differences of all point pair combinations
         over their separating distance, without sorting them into a lag.
 
+        .. versionchanged:: 0.4.0
+            This plot can be plotted with the plotly plotting backend
+
         Parameters
         ----------
         ax : None, AxesSubplot
@@ -1662,40 +1665,16 @@ class Variogram(object):
         matplotlib.pyplot.Figure
 
         """
-        # get all distances
-        _dist = self.distance
+        # get the backend
+        used_backend = plotting.backend()
 
-        # get all differences
-        if self._diff is None:
-            self._calc_diff()
-        _diff = self._diff
+        if used_backend == 'matplotlib':
+            return plotting.matplotlib_variogram_scattergram(self, ax=ax, plot_bins=plot_bins, show=show)
+        elif used_backend == 'plotly':
+            return plotting.plotly_dd_plot(self, fig=ax, plot_bins=plot_bins, show=show)
 
-        # create the plot
-        if ax is None:
-            fig, ax = plt.subplots(1, 1, figsize=(8, 6))
-        else:
-            fig = ax.get_figure()
-
-        # plot the bins
-        if plot_bins:
-            _bins = self.bins
-            ax.vlines(_bins, 0, np.max(_diff), linestyle='--', lw=1, color='r')
-
-        # plot
-        ax.scatter(_dist, _diff, 8, color='b', marker='o', alpha=0.5)
-
-        # set limits
-        ax.set_ylim((0, np.max(_diff)))
-        ax.set_xlim((0, np.max(_dist)))
-        ax.set_xlabel('separating distance')
-        ax.set_ylabel('pairwise difference')
-        ax.set_title('Pairwise distance ~ difference')
-
-        # show the plot
-        if show:  # pragma: no cover
-            fig.show()
-
-        return fig
+        # if we reach this line, somethings wrong with plotting backend
+        raise ValueError('The plotting backend has an undefined state.')
 
     def __repr__(self):  # pragma: no cover
         """

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -1562,41 +1562,39 @@ class Variogram(object):
         raise ValueError('The plotting backend has an undefined state.')
 
     def scattergram(self, ax=None, show=True):
+        """Scattergram plot
 
-        # create a new plot or use the given
-        if ax is None:
-            fig, ax = plt.subplots(1, 1)
-        else:
-            fig = ax.get_figure()
+        Groups the values by lags and plots the head and tail values
+        of all point pairs within the groups against each other.
+        This can be used to investigate the distribution of the
+        value residuals.
 
-        tail = np.empty(0)
-        head = tail.copy()
+        Parameters
+        ----------
+        ax : matplotlib.Axes, plotly.graph_objects.Figure
+            If None, a new plotting Figure will be created. If given, 
+            it has to be an instance of the used plotting backend, which 
+            will be used to plot on.
+        show : boolean
+            If True (default), the `show` method of the Figure will be 
+            called. Can be set to False to prevent duplicated plots in 
+            some environments.
+        
+        Returns
+        -------
+        fig : matplotlib.Figure, plotly.graph_objects.Figure
+            Resulting figure, depending on the plotting backend
+        """
+        # get the backend
+        used_backend = plotting.backend()
 
-        for h in np.unique(self.lag_groups()):
-            # get the head and tail
-            x, y = np.where(squareform(self.lag_groups()) == h)
+        if used_backend == 'matplotlib':
+            return plotting.matplotlib_variogram_scattergram(self, ax=ax, show=show)
+        elif used_backend == 'plotly':
+            return plotting.plotly_variogram_scattergram(self, fig=ax, show=show)
 
-            # concatenate
-            tail = np.concatenate((tail, self.values[x]))
-            head = np.concatenate((head, self.values[y]))
-
-        # plot the mean on tail and head
-        ax.vlines(np.mean(tail), np.min(tail), np.max(tail), linestyles='--',
-                  color='red', lw=2)
-        ax.hlines(np.mean(head), np.min(head), np.max(head), linestyles='--',
-                  color='red', lw=2)
-        # plot
-        ax.scatter(tail, head, 10, marker='o', color='orange')
-
-        # annotate
-        ax.set_ylabel('head')
-        ax.set_xlabel('tail')
-
-        # show the figure
-        if show:  # pragma: no cover
-            fig.show()
-
-        return fig
+        # if we reach this line, somethings wrong with plotting backend
+        raise ValueError('The plotting backend has an undefined state.')
 
     def location_trend(self, axes=None, show=True):
         """Location Trend plot

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -13,6 +13,7 @@ from scipy.spatial.distance import pdist, squareform
 from sklearn.isotonic import IsotonicRegression
 
 from skgstat import estimators, models, binning
+from skgstat import plotting
 
 
 class Variogram(object):
@@ -1549,88 +1550,16 @@ class Variogram(object):
         matplotlib.Figure
 
         """
-        # get the parameters
-        _bins = self.bins
-        _exp = self.experimental
-        x = np.linspace(0, np.nanmax(_bins), 100)  # make the 100 a param?
+        # get the backend
+        used_backend = plotting.backend()
 
-        # do the plotting
-        if axes is None:
-            if hist:
-                fig = plt.figure(figsize=(8, 5))
-                ax1 = plt.subplot2grid((5, 1), (1, 0), rowspan=4)
-                ax2 = plt.subplot2grid((5, 1), (0, 0), sharex=ax1)
-                fig.subplots_adjust(hspace=0)
-            else:
-                fig, ax1 = plt.subplots(1, 1, figsize=(8, 4))
-                ax2 = None
-        elif isinstance(axes, (list, tuple, np.ndarray)):
-            ax1, ax2 = axes
-            fig = ax1.get_figure()
-        else:
-            ax1 = axes
-            ax2 = None
-            fig = ax1.get_figure()
+        if used_backend == 'matplotlib':
+            return plotting.matplotlib_variogram_plot(self, axes=axes, grid=grid, show=show, hist=hist)
+        elif used_backend == 'plotly':
+            return plotting.plotly_variogram_plot(self, fig=axes, grid=grid, show=show, hist=hist)
 
-        # apply the model
-        y = self.transform(x)
-
-        # handle the relative experimental variogram
-        if self.normalized:
-            _bins /= np.nanmax(_bins)
-            y /= np.max(_exp)
-            _exp /= np.nanmax(_exp)
-            x /= np.nanmax(x)
-
-        # ------------------------
-        # plot Variograms
-        ax1.plot(_bins, _exp, '.b')
-        ax1.plot(x, y, '-g')
-
-        # ax limits
-        if self.normalized:
-            ax1.set_xlim([0, 1.05])
-            ax1.set_ylim([0, 1.05])
-        if grid:
-            ax1.grid(False)
-            ax1.vlines(_bins, *ax1.axes.get_ybound(), colors=(.85, .85, .85),
-                       linestyles='dashed')
-        # annotation
-        ax1.axes.set_ylabel('semivariance (%s)' % self._estimator.__name__)
-        ax1.axes.set_xlabel('Lag (-)')
-
-        # ------------------------
-        # plot histogram
-        if ax2 is not None and hist:
-            # calc the histogram
-            _count = np.fromiter(
-                (g.size for g in self.lag_classes()), dtype=int
-            )
-
-            # set the sum of hist bar widths to 70% of the x-axis space
-            w = (np.max(_bins) * 0.7) / len(_count)
-
-            # plot
-            ax2.bar(_bins, _count, width=w, align='center', color='red')
-
-            # adjust
-            plt.setp(ax2.axes.get_xticklabels(), visible=False)
-            ax2.axes.set_yticks(ax2.axes.get_yticks()[1:])
-
-            # need a grid?
-            if grid:  #pragma: no cover
-                ax2.grid(False)
-                ax2.vlines(_bins, *ax2.axes.get_ybound(),
-                           colors=(.85, .85, .85), linestyles='dashed')
-
-            # anotate
-            ax2.axes.set_ylabel('N')
-
-        # show the figure
-        if show:  # pragma: no cover
-            fig.show()
-
-        return fig
+        # if we reach this line, somethings wrong with plotting backend
+        raise ValueError('The plotting backend has an undefined state.')
 
     def scattergram(self, ax=None, show=True):
 

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -1564,7 +1564,7 @@ class Variogram(object):
         # if we reach this line, somethings wrong with plotting backend
         raise ValueError('The plotting backend has an undefined state.')
 
-    def scattergram(self, ax=None, show=True):
+    def scattergram(self, ax=None, show=True):  # pragma: no cover
         """Scattergram plot
 
         Groups the values by lags and plots the head and tail values

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -1669,7 +1669,7 @@ class Variogram(object):
         used_backend = plotting.backend()
 
         if used_backend == 'matplotlib':
-            return plotting.matplotlib_variogram_scattergram(self, ax=ax, plot_bins=plot_bins, show=show)
+            return plotting.matplotlib_dd_plot(self, ax=ax, plot_bins=plot_bins, show=show)
         elif used_backend == 'plotly':
             return plotting.plotly_dd_plot(self, fig=ax, plot_bins=plot_bins, show=show)
 

--- a/skgstat/__init__.py
+++ b/skgstat/__init__.py
@@ -7,3 +7,4 @@ from . import interfaces
 # set some stuff
 __version__ = '0.3.1'
 __author__ = 'Mirko Maelicke <mirko.maelicke@kit.edu>'
+__backend__ = 'matplotlib'

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -1,6 +1,8 @@
 import skgstat
+
 from .variogram_plot import matplotlib_variogram_plot, plotly_variogram_plot
 from .variogram_scattergram import matplotlib_variogram_scattergram, plotly_variogram_scattergram
+from .variogram_location_trend import matplotlib_location_trend, plotly_location_trend
 
 ALLOWED_BACKENDS = [
     'matplotlib',

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -4,7 +4,7 @@ from .variogram_plot import matplotlib_variogram_plot, plotly_variogram_plot
 from .variogram_scattergram import matplotlib_variogram_scattergram, plotly_variogram_scattergram
 from .variogram_location_trend import matplotlib_location_trend, plotly_location_trend
 from .variogram_dd_plot import matplotlib_dd_plot, plotly_dd_plot
-from .directtional_variogram import matplotlib_pair_field
+from .directtional_variogram import matplotlib_pair_field, plotly_pair_field
 
 
 ALLOWED_BACKENDS = [

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -6,6 +6,7 @@ from .variogram_location_trend import matplotlib_location_trend, plotly_location
 from .variogram_dd_plot import matplotlib_dd_plot, plotly_dd_plot
 from .directtional_variogram import matplotlib_pair_field, plotly_pair_field
 from .stvariogram_plot3d import matplotlib_plot_3d, plotly_plot_3d
+from .stvariogram_plot2d import matplotlib_plot_2d, plotly_plot_2d
 
 
 ALLOWED_BACKENDS = [

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -7,6 +7,7 @@ from .variogram_dd_plot import matplotlib_dd_plot, plotly_dd_plot
 from .directtional_variogram import matplotlib_pair_field, plotly_pair_field
 from .stvariogram_plot3d import matplotlib_plot_3d, plotly_plot_3d
 from .stvariogram_plot2d import matplotlib_plot_2d, plotly_plot_2d
+from .stvariogram_marginal import matplotlib_marginal, plotly_marginal
 
 
 ALLOWED_BACKENDS = [

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -5,6 +5,7 @@ from .variogram_scattergram import matplotlib_variogram_scattergram, plotly_vari
 from .variogram_location_trend import matplotlib_location_trend, plotly_location_trend
 from .variogram_dd_plot import matplotlib_dd_plot, plotly_dd_plot
 from .directtional_variogram import matplotlib_pair_field, plotly_pair_field
+from .stvariogram_plot3d import matplotlib_plot_3d, plotly_plot_3d
 
 
 ALLOWED_BACKENDS = [

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -3,6 +3,8 @@ import skgstat
 from .variogram_plot import matplotlib_variogram_plot, plotly_variogram_plot
 from .variogram_scattergram import matplotlib_variogram_scattergram, plotly_variogram_scattergram
 from .variogram_location_trend import matplotlib_location_trend, plotly_location_trend
+from .variogram_dd_plot import matplotlib_dd_plot, plotly_dd_plot
+
 
 ALLOWED_BACKENDS = [
     'matplotlib',

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -1,5 +1,6 @@
 import skgstat
 from .variogram_plot import matplotlib_variogram_plot, plotly_variogram_plot
+from .variogram_scattergram import matplotlib_variogram_scattergram, plotly_variogram_scattergram
 
 ALLOWED_BACKENDS = [
     'matplotlib',

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -4,6 +4,7 @@ from .variogram_plot import matplotlib_variogram_plot, plotly_variogram_plot
 from .variogram_scattergram import matplotlib_variogram_scattergram, plotly_variogram_scattergram
 from .variogram_location_trend import matplotlib_location_trend, plotly_location_trend
 from .variogram_dd_plot import matplotlib_dd_plot, plotly_dd_plot
+from .directtional_variogram import matplotlib_pair_field
 
 
 ALLOWED_BACKENDS = [

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -1,0 +1,23 @@
+import skgstat
+from .variogram_plot import matplotlib_variogram_plot, plotly_variogram_plot
+
+ALLOWED_BACKENDS = [
+    'matplotlib',
+    'plotly'
+]
+
+
+def backend(name=None):
+    """
+    """
+    if name is None:
+        return skgstat.__backend__
+
+    elif name not in ALLOWED_BACKENDS:
+        raise ValueError(
+            "'%s' is not an allowed plotting backend.\nOptions are: [%s]" % 
+            (name, ','.join(["'%s'" % _ for _ in ALLOWED_BACKENDS]))
+        )
+
+    else:
+        skgstat.__backend__ = name

--- a/skgstat/plotting/__init__.py
+++ b/skgstat/plotting/__init__.py
@@ -20,5 +20,12 @@ def backend(name=None):
             (name, ','.join(["'%s'" % _ for _ in ALLOWED_BACKENDS]))
         )
 
-    else:
-        skgstat.__backend__ = name
+    elif name == 'plotly':
+        try:
+            import plotly
+        except ImportError:
+            print('You need to install plotly >=4.12.0 separatly:\npip install plotly')
+            return
+
+    # were are good to set the new backend
+    skgstat.__backend__ = name

--- a/skgstat/plotting/directtional_variogram.py
+++ b/skgstat/plotting/directtional_variogram.py
@@ -1,0 +1,71 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
+from scipy.spatial.distance import squareform
+
+try:
+    import plotly.graph_objects as go
+except ImportError:
+    pass    
+
+
+def __calculate_plot_data(variogram, points):
+    # get the direction mask
+    mask = squareform(variogram._direction_mask())
+
+    # build a coordinate meshgrid
+    r = np.arange(len(self._X))
+    x1, x2 = np.meshgrid(r, r)
+    start = self._X[x1[mask]]
+    end = self._X[x2[mask]]
+
+    # handle lesser points
+    if isinstance(points, int):
+        points = [points]
+    if isinstance(points, list):
+        _start, _end = list(), list()
+        for p in self._X[points]:
+            _start.extend(start[np.where(end == p)[0]])
+            _end.extend(end[np.where(end == p)[0]])
+        start = np.array(_start)
+        end = np.array(_end)
+
+        # extract all lines
+        lines = np.column_stack((
+            start.reshape(len(start), 1, 2), 
+            end.reshape(len(end), 1, 2)
+        ))
+
+        return lines
+
+
+def matplotlib_pair_field(variogram, ax=None, cmap='gist_rainbow', points='all', add_points=True, alpha=0.3, **kwargs):
+    # get the plot data
+    lines = __calculate_plot_data(variogram, points)
+ 
+    # align the colors
+    colors = plt.cm.get_cmap(cmap)(np.linspace(0, 1, len(lines)))
+    colors[:, 3] = alpha
+
+    # get the figure and ax object
+    if ax is None:
+        figsize = kwargs.get('figsize', (8, 8))
+        fig, ax = plt.subplots(1, 1, figsize=figsize)
+    else:
+        fig = ax.get_figure()
+
+    # plot
+    lc = LineCollection(lines, colors=colors, linewidths=1)
+    ax.add_collection(lc)
+        
+    # add coordinates
+    if add_points:
+        ax.scatter(variogram._X[:, 0], variogram._X[:, 1], 15, c='k')
+        if isinstance(points, list):
+            ax.scatter(variogram._X[:, 0][points], variogram._X[:, 1][points], 25, c='r')
+
+    # finish plot
+    ax.autoscale()
+    ax.margins(0.1)
+
+    return fig

--- a/skgstat/plotting/directtional_variogram.py
+++ b/skgstat/plotting/directtional_variogram.py
@@ -30,13 +30,13 @@ def __calculate_plot_data(variogram, points):
         start = np.array(_start)
         end = np.array(_end)
 
-        # extract all lines
-        lines = np.column_stack((
-            start.reshape(len(start), 1, 2),
-            end.reshape(len(end), 1, 2)
-        ))
+    # extract all lines
+    lines = np.column_stack((
+        start.reshape(len(start), 1, 2),
+        end.reshape(len(end), 1, 2)
+    ))
 
-        return lines
+    return lines
 
 
 def matplotlib_pair_field(variogram, ax=None, cmap='gist_rainbow', points='all', add_points=True, alpha=0.3, **kwargs):
@@ -57,7 +57,7 @@ def matplotlib_pair_field(variogram, ax=None, cmap='gist_rainbow', points='all',
     # plot
     lc = LineCollection(lines, colors=colors, linewidths=1)
     ax.add_collection(lc)
-        
+
     # add coordinates
     if add_points:
         ax.scatter(variogram._X[:, 0], variogram._X[:, 1], 15, c='k')

--- a/skgstat/plotting/directtional_variogram.py
+++ b/skgstat/plotting/directtional_variogram.py
@@ -14,17 +14,17 @@ def __calculate_plot_data(variogram, points):
     mask = squareform(variogram._direction_mask())
 
     # build a coordinate meshgrid
-    r = np.arange(len(self._X))
+    r = np.arange(len(variogram._X))
     x1, x2 = np.meshgrid(r, r)
-    start = self._X[x1[mask]]
-    end = self._X[x2[mask]]
+    start = variogram._X[x1[mask]]
+    end = variogram._X[x2[mask]]
 
     # handle lesser points
     if isinstance(points, int):
         points = [points]
     if isinstance(points, list):
         _start, _end = list(), list()
-        for p in self._X[points]:
+        for p in variogram._X[points]:
             _start.extend(start[np.where(end == p)[0]])
             _end.extend(end[np.where(end == p)[0]])
         start = np.array(_start)
@@ -32,7 +32,7 @@ def __calculate_plot_data(variogram, points):
 
         # extract all lines
         lines = np.column_stack((
-            start.reshape(len(start), 1, 2), 
+            start.reshape(len(start), 1, 2),
             end.reshape(len(end), 1, 2)
         ))
 
@@ -42,7 +42,7 @@ def __calculate_plot_data(variogram, points):
 def matplotlib_pair_field(variogram, ax=None, cmap='gist_rainbow', points='all', add_points=True, alpha=0.3, **kwargs):
     # get the plot data
     lines = __calculate_plot_data(variogram, points)
- 
+
     # align the colors
     colors = plt.cm.get_cmap(cmap)(np.linspace(0, 1, len(lines)))
     colors[:, 3] = alpha

--- a/skgstat/plotting/directtional_variogram.py
+++ b/skgstat/plotting/directtional_variogram.py
@@ -6,7 +6,7 @@ from scipy.spatial.distance import squareform
 try:
     import plotly.graph_objects as go
 except ImportError:
-    pass    
+    pass
 
 
 def __calculate_plot_data(variogram, points):
@@ -40,7 +40,14 @@ def __calculate_plot_data(variogram, points):
     return lines
 
 
-def matplotlib_pair_field(variogram, ax=None, cmap='gist_rainbow', points='all', add_points=True, alpha=0.3, **kwargs):
+def matplotlib_pair_field(
+    variogram, ax=None,
+    cmap='gist_rainbow',
+    points='all',
+    add_points=True,
+    alpha=0.3,
+    **kwargs
+):
     # get the plot data
     lines = __calculate_plot_data(variogram, points)
 
@@ -63,7 +70,11 @@ def matplotlib_pair_field(variogram, ax=None, cmap='gist_rainbow', points='all',
     if add_points:
         ax.scatter(variogram._X[:, 0], variogram._X[:, 1], 15, c='k')
         if isinstance(points, list):
-            ax.scatter(variogram._X[:, 0][points], variogram._X[:, 1][points], 25, c='r')
+            ax.scatter(
+                variogram._X[:, 0][points],
+                variogram._X[:, 1][points],
+                25, c='r'
+            )
 
     # finish plot
     ax.autoscale()
@@ -72,8 +83,15 @@ def matplotlib_pair_field(variogram, ax=None, cmap='gist_rainbow', points='all',
     return fig
 
 
-def plotly_pair_field(variogram, fig=None, points='all', add_points=True, alpha=0.3, **kwargs):
-    # get the plot data 
+def plotly_pair_field(
+    variogram,
+    fig=None,
+    points='all',
+    add_points=True,
+    alpha=0.3,
+    **kwargs
+):
+    # get the plot data
     lines = __calculate_plot_data(variogram, points)
 
     # create a figure if none is passed
@@ -92,7 +110,7 @@ def plotly_pair_field(variogram, fig=None, points='all', add_points=True, alpha=
         y = variogram._X[:, 1]
         fig.add_trace(
             go.Scatter(
-                x=x, y=y, mode='markers', 
+                x=x, y=y, mode='markers',
                 marker=dict(color='black', size=5),
                 text=['Coord: #%d' % i for i in range(len(x))]
             )
@@ -102,7 +120,7 @@ def plotly_pair_field(variogram, fig=None, points='all', add_points=True, alpha=
                 go.Scatter(
                     x=x[points], y=y[points], mode='markers',
                     marker=dict(color='red', size=15),
-                    text=['Coordinate: #%d' % p for p in points]   
+                    text=['Coordinate: #%d' % p for p in points]
                 )
             )
 

--- a/skgstat/plotting/stvariogram_marginal.py
+++ b/skgstat/plotting/stvariogram_marginal.py
@@ -1,0 +1,154 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+try:
+    import plotly.graph_objects as go
+    from plotly.subplots import make_subplots
+except ImportError:
+    pass
+
+
+def __calc_plot_data(stvariogram, **kwargs):
+    # get the marginal experimental variograms
+    vx = stvariogram.XMarginal.experimental
+    vy = stvariogram.TMarginal.experimental
+
+    res = kwargs.get('model_resolution', 100)
+
+    # get the model
+    xx = np.linspace(0, stvariogram.xbins[-1], res)
+    xy = np.linspace(0, stvariogram.tbins[-1], res)
+    y_vx = stvariogram.XMarginal.transform(xx)
+    y_vy = stvariogram.TMarginal.transform(xy)
+
+    return xx, xy, y_vx, y_vy
+
+
+def matplotlib_marginal(stvariogram, axes=None, sharey=True, include_model=False, **kwargs):
+    # check if an ax needs to be created
+    if axes is None:
+        fig, axes = plt.subplots(1, 2, figsize=kwargs.get('figsize', (12, 6)),sharey=sharey)
+    else:
+        if len(axes) != 2:
+            raise ValueError('axes needs to an array of two AxesSubplot objects')
+        fig = axes[0].get_figure()
+
+    # get some settings
+    x_style = kwargs.get('x_style', 'ok' if include_model else '-ob')
+    t_style = kwargs.get('t_style', 'ok' if include_model else '-og')
+
+    # handle the twin axes
+    ax = axes[0]
+    ax2 = axes[1]
+    ax3 = ax2.twinx()
+    ax3.get_shared_y_axes().join(ax3, ax)
+
+    # plot the marginal experimental variogram
+    ax.plot(stvariogram.xbins, stvariogram.XMarginal.experimental, x_style)
+    ax3.plot(stvariogram.tbins, stvariogram.TMarginal.experimental, t_style)
+
+    if include_model:
+        xx, xy, y_vx, y_vy = __calc_plot_data(stvariogram, **kwargs)
+
+        # plot
+        ax.plot(xx, y_vx, '-b')
+        ax.plot(xy, y_vy, '-g')
+    
+    # set labels
+    ax.set_xlabel('distance [spatial]')
+    ax.set_ylabel('semivariance [%s]' % stvariogram.estimator.__name__)
+    ax2.set_xlabel('distance [temporal]')
+    if not sharey:
+        ax3.set_ylabel('semivariance [%s]' % stvariogram.estimator.__name__)
+
+    # set title and grid
+    ax.set_title('spatial marginal variogram')
+    ax2.set_title('temporal marginal variogram')
+
+    ax.grid(which='major')
+    ax2.grid(which='major')
+    plt.tight_layout()
+
+    # return
+    return fig
+
+
+def plotly_marginal(stvariogram, fig=None, include_model=False, **kwargs):
+    shared_yaxes = kwargs.get('sharey', kwargs.get('shared_yaxis', True))
+    # check if a figure needs to be created
+    if fig is None:
+        fig = go.Figure()
+    try:
+        fig.set_subplots(rows=1, cols=2, shared_yaxes=shared_yaxes)
+    except ValueError:
+        # figure has alredy subplots
+        pass
+
+    # get some settings
+    x_color = kwargs.get('x_color', 'black' if include_model else 'green')
+    t_color = kwargs.get('t_color', 'black' if include_model else 'blue')
+    
+    # plot the marginal experimental variogram
+    fig.add_trace(
+        go.Scatter(
+            name='Spatial marginal variogram',
+            x=stvariogram.xbins,
+            y=stvariogram.XMarginal.experimental,
+            mode='markers' if include_model else 'markers+lines',
+            marker=dict(color=x_color),
+            line=dict(color=x_color),
+        ), row=1, col=1
+    )
+    fig.add_trace(
+        go.Scatter(
+            name='Temporal marginal variogram',
+            x=stvariogram.tbins,
+            y=stvariogram.TMarginal.experimental,
+            mode='markers' if include_model else 'markers+lines',
+            marker=dict(color=t_color),
+            line=dict(color=t_color)
+        ), row=1, col=2
+    )
+
+    # handle models
+    if include_model:
+        xx, yy, y_vx, y_vy = __calc_plot_data(stvariogram, **kwargs)
+
+        # add the models
+        fig.add_trace(
+            go.Scatter(
+                name='spatial %s model' % stvariogram.XMarginal.model.__name__,
+                x=xx,
+                y=y_vx,
+                mode='lines',
+                line=dict(color='blue')
+            ), row=1, col=1
+        )
+        fig.add_trace(
+            go.Scatter(
+                name='temporal %s model' % stvariogram.TMarginal.model.__name__,
+                x=yy,
+                y=y_vy,
+                mode='lines',
+                line=dict(color='green')
+            ), row=1, col=2
+        )
+
+    # update the layout
+    fig.update_xaxes(title_text='distance [spatial]', row=1, col=1)
+    fig.update_xaxes(title_text='distance [temporal]', row=1, col=2)
+    fig.update_yaxes(title_text='semivariance [%s]' % stvariogram.estimator.__name__, row=1, col=1)
+    if not shared_yaxes:
+        fig.update_yaxes(title_text='semivariance [%s]' % stvariogram.estimator.__name__, row=1, col=2)
+
+    fig.update_layout(
+        legend=dict(
+            orientation='h',
+            x=0,
+            y=1.05,
+            xanchor='left',
+            yanchor='bottom'
+        )
+    )
+
+    return fig

--- a/skgstat/plotting/stvariogram_plot2d.py
+++ b/skgstat/plotting/stvariogram_plot2d.py
@@ -1,0 +1,115 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from scipy.ndimage.interpolation import zoom
+from scipy.interpolate import griddata
+
+try:
+    import plotly.graph_objects as go
+except ImportError:
+    pass
+
+
+def matplotlib_plot_2d(stvariogram, kind='contour', ax=None, zoom_factor=100., levels=10, method='fast', **kwargs):
+    # get or create the figure
+    if ax is not None:
+        fig = ax.get_figure()
+    else:
+        fig, ax = plt.subplots(1, 1, figsize=kwargs.get('figsize', (8, 8)))
+
+    # prepare the meshgrid
+    xx, yy = stvariogram.meshbins
+    z = stvariogram.experimental
+    x = xx.flatten()
+    y = yy.flatten()
+
+    xxi = zoom(xx, zoom_factor, order=1)
+    yyi = zoom(yy, zoom_factor, order=1)
+
+    # interpolation, either fast or precise
+    if method.lower() == "fast":
+        zi = zoom(z.reshape((stvariogram.t_lags, stvariogram.x_lags)), zoom_factor, order=1, prefilter=False)
+    elif method.lower() == "precise":
+        # zoom the meshgrid by linear interpolation
+        # interpolate the semivariance
+        zi = griddata((x, y), z, (xxi, yyi), method='linear')
+    else:
+        raise ValueError("method has to be one of ['fast', 'precise']")
+
+    # get the bounds
+    zmin = np.nanmin(zi)
+    zmax = np.nanmax(zi)
+
+    # get the plotting parameters
+    lev = np.linspace(0, zmax, levels)
+    c = kwargs.get('color', kwargs.get('c', 'k'))
+    cmap = kwargs.get('cmap', 'RdYlBu_r')
+
+    # plot
+    if kind.lower() == 'contour':
+        ax.contour(xxi, yyi, zi, colors=c, levels=lev, vmin=zmin * 1.1, vmax=zmax * 0.9, linewidths=kwargs.get('linewidths', 0.3))
+    elif kind.lower() == 'contourf':
+        C = ax.contourf(xxi, yyi, zi, cmap=cmap, levels=lev, vmin=zmin *1.1, vmax=zmax * 0.9)
+        if kwargs.get('colorbar', True):
+            plt.colorbar(C, ax=ax)
+    else:
+        raise ValueError("%s is not a valid 2D plot" % kind)
+
+    # some labels
+    ax.set_xlabel(kwargs.get('xlabel', 'space'))
+    ax.set_ylabel(kwargs.get('ylabel', 'time'))
+    ax.set_xlim(kwargs.get('xlim', (0, stvariogram.xbins[-1])))
+    ax.set_ylim(kwargs.get('ylim', (0, stvariogram.tbins[-1])))
+
+    return fig
+
+
+def plotly_plot_2d(stvariogram, kind='contour', fig=None, **kwargs):
+    # get base data
+    x = stvariogram.xbins
+    y = stvariogram.tbins
+    z = stvariogram.experimental.reshape((len(x), len(y)))
+
+    # get settings
+    showlabels = kwargs.get('showlabels', True)
+    colorscale = kwargs.get('colorscale', 'Earth_r')
+    smooth = kwargs.get('line_smoothing', 0.0)
+    coloring = kwargs.get('coloring', 'heatmap')
+    if kind == 'contourf':
+        coloring = 'lines'
+        lw = kwargs.get('line_width', kwargs.get('lw', 2))
+        label_color = kwargs.get('label_color', 'black')
+    else:
+        label_color = kwargs.get('label_color', 'white')
+        lw = kwargs.get('line_width', kwargs.get('lw', .3))
+
+    # get the figure
+    if fig is None:
+        fig = go.Figure()
+
+    # do the plot
+    fig.add_trace(
+        go.Contour(
+            x=x,
+            y=y,
+            z=z,
+            line_smoothing=smooth,
+            colorscale=colorscale,
+            contours=dict(
+                coloring=coloring,
+                showlabels=showlabels,
+                labelfont=dict(
+                    color=label_color,
+                    size=kwargs.get('label_size', 14)
+                )
+            ),
+            line_width=lw
+        )
+    )
+
+    # update the labels
+    fig.update_layout(scene=dict(
+        xaxis_title=kwargs.get('xlabel', 'space'),
+        yaxis_title=kwargs.get('ylabel', 'time')
+    ))
+
+    return fig

--- a/skgstat/plotting/stvariogram_plot3d.py
+++ b/skgstat/plotting/stvariogram_plot3d.py
@@ -95,7 +95,8 @@ def plotly_plot_3d(stvariogram, kind='scatter', fig=None, **kwargs):
                 y=yy,
                 z=z.reshape(xx.shape),
                 opacity=0.8 * alpha,
-                colorscale=[[0, c], [1, c]]
+                colorscale=[[0, c], [1, c]],
+                name='experimental variogram'
             )
         )
     elif kind == 'scatter' or kwargs.get('add_points', False):
@@ -107,7 +108,7 @@ def plotly_plot_3d(stvariogram, kind='scatter', fig=None, **kwargs):
                 mode='markers',
                 opacity=alpha,
                 marker=dict(color=c, size=kwargs.get('size', 4)),
-                name='experimental'
+                name='experimental variogram'
             )
         )
 

--- a/skgstat/plotting/stvariogram_plot3d.py
+++ b/skgstat/plotting/stvariogram_plot3d.py
@@ -1,0 +1,135 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import Axes3D
+
+try:
+    import plotly.graph_objects as go
+except ImportError:
+    pass
+
+
+def __calculate_plot_data(stvariogram, **kwargs):
+    xx, yy = stvariogram.meshbins
+    z = stvariogram.experimental
+#    x = xx.flatten()
+#    y = yy.flatten()
+
+    # apply the model
+    nx = kwargs.get('x_resolution', 100)
+    nt = kwargs.get('t_resolution', 100)
+
+    # model spacing
+    _xx, _yy = np.mgrid[
+        0:np.nanmax(stvariogram.xbins):nx * 1j,
+        0:np.nanmax(stvariogram.tbins):nt * 1j
+    ]
+    model = stvariogram.fitted_model
+    lags = np.vstack((_xx.flatten(), _yy.flatten())).T
+    # apply the model
+    _z = model(lags)
+
+    return xx, yy, z, _xx, _yy, _z
+
+
+def matplotlib_plot_3d(stvariogram, kind='scatter', ax=None, elev=30, azim=220, **kwargs):
+    # get the data, spanned over a bin meshgrid
+    xx, yy, z, _xx, _yy, _z = __calculate_plot_data(stvariogram, **kwargs)
+    x = xx.flatten()
+    y = yy.flatten()
+
+    # some settings
+    c = kwargs.get('color', kwargs.get('c', 'b'))
+    cmap = kwargs.get('model_color', kwargs.get('cmap', 'terrain'))
+    alpha = kwargs.get('alpha', 0.8)
+    depthshade = kwargs.get('depthshade', False)
+
+    # handle the axes
+    if ax is not None:
+        if not isinstance(ax, Axes3D):
+            raise ValueError('The passed ax object is not an instance of mpl_toolkis.mplot3d.Axes3D.')
+        fig = ax.get_figure()
+    else:
+        fig = plt.figure(figsize=kwargs.get('figsize', (10, 10)))
+        ax = fig.add_subplot(111, projection='3d')
+
+    # do the plot
+    ax.view_init(elev=elev, azim=azim)
+    if kind == 'surf':
+        ax.plot_trisurf(x, y, z, color=c, alpha=alpha)
+    elif kind == 'scatter':
+        ax.scatter(x, y, z, c=c, depthshade=depthshade)
+    else:
+        raise ValueError('%s is not a valid 3D plot' % kind)
+
+
+    # add the model
+    ax.plot_trisurf(_xx.flatten(), _yy.flatten(), _z, cmap=cmap, alpha=alpha)
+
+    # labels:
+    ax.set_xlabel('space')
+    ax.set_ylabel('time')
+    ax.set_zlabel('semivariance [%s]' % stvariogram.estimator.__name__)
+
+    # return
+    return fig
+
+
+def plotly_plot_3d(stvariogram, kind='scatter', fig=None, **kwargs):
+    # get the data spanned over a bin meshgrid
+    xx, yy, z, _xx, _yy, _z = __calculate_plot_data(stvariogram, **kwargs)
+
+    # get some settings
+    c = kwargs.get('color', kwargs.get('c', 'black'))
+    cmap = kwargs.get('model_color', kwargs.get('colorscale', kwargs.get('cmap', 'Electric')))
+    alpha = kwargs.get('opacity', kwargs.get('alpha', 0.6))
+
+    # handle the figue
+    if fig is None:
+        fig = go.Figure()
+
+    # do the plot
+    if kind == 'surf':
+        fig.add_trace(
+            go.Surface(
+                x=xx,
+                y=yy,
+                z=z.reshape(xx.shape),
+                opacity=0.8 * alpha,
+                colorscale=[[0, c], [1, c]]
+            )
+        )
+    elif kind == 'scatter' or kwargs.get('add_points', False):
+        fig.add_trace(
+            go.Scatter3d(
+                x=xx.flatten(),
+                y=yy.flatten(),
+                z=z,
+                mode='markers',
+                opacity=alpha,
+                marker=dict(color=c, size=kwargs.get('size', 4)),
+                name='experimental'
+            )
+        )
+
+    # add the model
+    if not kwargs.get('no_model', False):
+        fig.add_trace(
+            go.Surface(
+                x=_xx,
+                y=_yy,
+                z=_z.reshape(_xx.shape),
+                opacity=max(1, alpha * 1.2),
+                colorscale=cmap,
+                name='%s model' % stvariogram.model.__name__
+            )
+        )
+
+    # set some labels
+    fig.update_layout(scene=dict(
+        xaxis_title='space',
+        yaxis_title='time',
+        zaxis_title='semivariance [%s]' % stvariogram.estimator.__name__
+    )) 
+
+    # return
+    return fig

--- a/skgstat/plotting/variogram_dd_plot.py
+++ b/skgstat/plotting/variogram_dd_plot.py
@@ -1,5 +1,5 @@
 import numpy as np
-import matplotlib as plt
+import matplotlib.pyplot as plt
 
 try:
     import plotly.graph_objects as go 

--- a/skgstat/plotting/variogram_dd_plot.py
+++ b/skgstat/plotting/variogram_dd_plot.py
@@ -1,0 +1,85 @@
+import numpy as np
+import matplotlib as plt
+
+try:
+    import plotly.graph_objects as go 
+except ImportError:
+    pass
+
+
+def __calculate_plot_data(variogram):
+   # get all distances
+    _dist = variogram.distance
+
+    # get all differences
+    if variogram._diff is None:
+        variogram._calc_diff()
+    _diff = variogram._diff
+
+    return _diff, _dist
+
+
+def matplotlib_dd_plot(variogram, ax=None, plot_bins=True, show=True):
+    # get the plotting data 
+    _diff, _dist = __calculate_plot_data(variogram)
+   
+    # create the plot
+    if ax is None:
+        fig, ax = plt.subplots(1, 1, figsize=(8, 6))
+    else:
+        fig = ax.get_figure()
+
+    # plot the bins
+    if plot_bins:
+        _bins = variogram.bins
+        ax.vlines(_bins, 0, np.max(_diff), linestyle='--', lw=1, color='r')
+
+    # plot
+    ax.scatter(_dist, _diff, 8, color='b', marker='o', alpha=0.5)
+
+    # set limits
+    ax.set_ylim((0, np.max(_diff)))
+    ax.set_xlim((0, np.max(_dist)))
+    ax.set_xlabel('separating distance')
+    ax.set_ylabel('pairwise difference')
+    ax.set_title('Pairwise distance ~ difference')
+
+    # show the plot
+    if show:  # pragma: no cover
+        fig.show()
+
+    return fig
+
+
+def plotly_dd_plot(variogram, fig=None, plot_bins=True, show=True):
+    # get the plotting data
+    _diff, _dist = __calculate_plot_data(variogram)
+
+    # create a new Figure if needed
+    if fig is None:
+        fig = go.Figure()
+
+    # plot
+    fig.add_trace(
+        go.Scattergl(
+            x=_dist, y=_diff, 
+            mode='markers', marker=dict(color='blue', opacity=0.5)
+        )
+    )
+
+    # plot the bins
+    if plot_bins:
+        for _bin in variogram.bins:
+            fig.add_vline(x=_bin, line_dash='dash', line_color='red')
+
+    # titles
+    fig.update_layout(
+        title='Pairwise distance ~ difference',
+        xaxis_title='separating distance',
+        yaxis_title='pairwise difference'
+    )
+
+    if show:
+        fig.show()
+
+    return fig

--- a/skgstat/plotting/variogram_location_trend.py
+++ b/skgstat/plotting/variogram_location_trend.py
@@ -1,0 +1,77 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+try:
+    from plotly.subplots import make_subplots
+    import plotly.graph_objects as go
+except ImportError:
+    pass
+
+
+def matplotlib_location_trend(variogram, axes=None, show=True):
+    N = len(variogram._X[0])
+
+    # create the figure
+    if axes is None:
+        # derive the needed amount of col and row
+        nrow = int(round(np.sqrt(N)))
+        ncol = int(np.ceil(N / nrow))
+        fig, axes = plt.subplots(nrow, ncol, figsize=(ncol * 6, nrow * 6))
+    else:
+        if not len(axes) == N:
+            raise ValueError(
+                'The amount of passed axes does not fit the coordinate' +
+                ' dimensionality of %d' % N
+            )
+        fig = axes[0].get_figure()
+
+    # plot
+    for i in range(N):
+        axes.flatten()[i].plot([_[i] for _ in variogram._X], variogram.values, '.r')
+        axes.flatten()[i].set_xlabel('%d-dimension' % (i + 1))
+        axes.flatten()[i].set_ylabel('value')
+
+    # decrease margins
+    plt.tight_layout()
+
+    # show if needed
+    if show:
+        fig.show()
+
+    return fig
+
+
+def plotly_location_trend(variogram, fig=None, show=True):
+    N = len(variogram._X[0])
+    if N <= 3:
+        names = ['X', 'Y', 'Z'][:N]
+    else:
+        names = ['%d. dimension' % _ for _ in range(N)]
+
+    # check if a figure is needed
+    if fig is None:
+        fig = make_subplots(rows=1, cols=1)
+
+    x = variogram.values
+    # switch to ScatterGL, if more than 5000 points will be plotted
+    if len(x) * N >= 5000:
+        GoCls = go.Scattergl
+    else:
+        GoCls = go.Scatter
+
+    # plot
+    for i in range(N):
+        y = variogram._X[:, i]
+        fig.add_trace(
+            GoCls(x=x, y=y, mode='markers', name=names[i]),
+            row=1, col=1
+        )
+
+    fig.update_xaxes(title_text='Value')
+    fig.update_yaxes(title_text='Coordinate dimension')
+
+    # show figure if needed
+    if show:
+        fig.show()
+
+    return fig

--- a/skgstat/plotting/variogram_plot.py
+++ b/skgstat/plotting/variogram_plot.py
@@ -1,0 +1,155 @@
+import numpy as np
+import matplotlib.pyplot as plt 
+
+try:
+    from plotly.subplots import make_subplots
+    import plotly.graph_objects as go 
+except ImportError:
+    pass
+
+
+def __calculate_plot_data(variogram):
+    # get the parameters
+    _bins = variogram.bins
+    _exp = variogram.experimental
+    x = np.linspace(0, np.nanmax(_bins), 100)
+
+    # apply the model
+    y = variogram.transform(x)
+
+    # handle the relative experimental variogram
+    if variogram.normalized:
+        _bins /= np.nanmax(_bins)
+        y /= np.max(_exp)
+        _exp /= np.nanmax(_exp)
+        x /= np.nanmax(x)
+
+    return x, y, _bins, _exp
+
+
+def matplotlib_variogram_plot(variogram, axes=None, grid=True, show=True, hist=True):
+    # get the plotting data
+    x, y, _bins, _exp = __calculate_plot_data(variogram)
+
+    # do the plotting
+    if axes is None:
+        if hist:
+            fig = plt.figure(figsize=(8, 5))
+            ax1 = plt.subplot2grid((5, 1), (1, 0), rowspan=4)
+            ax2 = plt.subplot2grid((5, 1), (0, 0), sharex=ax1)
+            fig.subplots_adjust(hspace=0)
+        else:
+            fig, ax1 = plt.subplots(1, 1, figsize=(8, 4))
+            ax2 = None
+    elif isinstance(axes, (list, tuple, np.ndarray)):
+        ax1, ax2 = axes
+        fig = ax1.get_figure()
+    else:
+        ax1 = axes
+        ax2 = None
+        fig = ax1.get_figure()
+
+    # ------------------------
+    # plot Variograms
+    ax1.plot(_bins, _exp, '.b')
+    ax1.plot(x, y, '-g')
+
+    # ax limits
+    if variogram.normalized:
+        ax1.set_xlim([0, 1.05])
+        ax1.set_ylim([0, 1.05])
+    if grid:
+        ax1.grid(False)
+        ax1.vlines(_bins, *ax1.axes.get_ybound(), colors=(.85, .85, .85), linestyles='dashed')
+        # annotation
+        ax1.axes.set_ylabel('semivariance (%s)' % variogram._estimator.__name__)
+        ax1.axes.set_xlabel('Lag (-)')
+
+    # ------------------------
+    # plot histogram
+    if ax2 is not None and hist:
+        # calc the histogram
+        _count = np.fromiter(
+            (g.size for g in variogram.lag_classes()), dtype=int
+        )
+
+        # set the sum of hist bar widths to 70% of the x-axis space
+        w = (np.max(_bins) * 0.7) / len(_count)
+
+        # plot
+        ax2.bar(_bins, _count, width=w, align='center', color='red')
+
+        # adjust
+        plt.setp(ax2.axes.get_xticklabels(), visible=False)
+        ax2.axes.set_yticks(ax2.axes.get_yticks()[1:])
+
+        # need a grid?
+        if grid:  # pragma: no cover
+            ax2.grid(False)
+            ax2.vlines(_bins, *ax2.axes.get_ybound(), colors=(.85, .85, .85), linestyles='dashed')
+
+        # anotate
+        ax2.axes.set_ylabel('N')
+
+    # show the figure
+    if show:  # pragma: no cover
+        fig.show()
+
+    return fig
+
+
+def plotly_variogram_plot(variogram, fig=None, grid=True, show=True, hist=True):
+    # get the plotting data
+    x, y, _bins, _exp = __calculate_plot_data(variogram)
+    
+    # create the figure
+    if fig is None:
+        if hist:
+            fig = make_subplots(
+                rows=5, cols=1, shared_xaxes=True, vertical_spacing=0.0,
+                specs=[
+                    [{}], [{'rowspan': 4}], [None], [None], [None]
+                ]
+            )
+        else:
+            fig = make_subplots(rows=1, cols=1)
+    elif isinstance(fig, go.Figure):
+        pass
+    else:
+        raise ValueError('axes has to be None or a plotly.Figure.')
+
+    # main plot
+    fig.add_trace(
+        go.Scatter(x=_bins, y=_exp, mode='markers',
+                   marker=dict(color='blue'), name='Experimental'),
+        row=2 if hist else 1, col=1
+    )
+    fig.add_trace(
+        go.Scatter(x=x, y=y, mode='lines', marker=dict(color='green'),
+            name='%s model' % variogram.model.__name__),
+        row=2 if hist else 1, col=1
+    )
+
+    # update axis title
+    fig.update_xaxes(title_text='Lag [-]')
+    fig.update_yaxes(
+        title_text='semivariance (%s)' % variogram.estimator.__name__,
+        row=2 if hist else 1, col=1
+    )
+
+    # hist
+    if hist:
+        # calculate
+        _count = np.fromiter((g.size for g in variogram.lag_classes()), dtype=int)
+
+        fig.add_trace(
+            go.Bar(x=_bins, y=_count, marker=dict(color='red'), name='Histogram')
+        )
+
+        # title
+        fig.update_yaxes(title_text='# of pairs', row=1, col=1)
+
+    if show:
+        fig.show()
+
+    return fig

--- a/skgstat/plotting/variogram_plot.py
+++ b/skgstat/plotting/variogram_plot.py
@@ -131,7 +131,7 @@ def plotly_variogram_plot(variogram, fig=None, grid=True, show=True, hist=True):
     )
 
     # update axis title
-    fig.update_xaxes(title_text='Lag [-]')
+    fig.update_xaxes(title_text='Lag [-]', row=2 if hist else 1, col=1)
     fig.update_yaxes(
         title_text='semivariance (%s)' % variogram.estimator.__name__,
         row=2 if hist else 1, col=1

--- a/skgstat/plotting/variogram_scattergram.py
+++ b/skgstat/plotting/variogram_scattergram.py
@@ -1,0 +1,85 @@
+import numpy as np
+from scipy.spatial.distance import squareform
+import matplotlib.pyplot as plt 
+
+try:
+    import plotly.graph_objects as go 
+except ImportError:
+    pass
+
+def __calculate_plot_data(variogram):
+    tail = np.empty(0)
+    head = tail.copy() 
+
+    sq_lags = squareform(variogram.lag_groups())
+
+    for h in np.unique(variogram.lag_groups()):
+        # get head and tail
+        x, y = np.where(sq_lags == h)
+
+        # add
+        tail = np.concatenate((tail, variogram.values[x]))
+        head = np.concatenate((head, variogram.values[y]))
+
+    return tail, head
+
+
+def matplotlib_variogram_scattergram(variogram, ax=None, show=True):
+    # get the plot data
+    tail, head = __calculate_plot_data(variogram)
+
+    # create a new figure or use the given
+    if ax is None:
+        fig, ax = plt.subplots(1, 1)
+    else:
+        fig = ax.get_figure()
+
+    # plot
+    ax.vlines(np.mean(tail), np.min(tail), np.max(tail), linestyles='--',
+        color='red', lw=2)
+    ax.hlines(np.mean(head), np.min(head), np.max(head), linestyles='--',
+        color='red', lw=2)
+    # plot
+    ax.scatter(tail, head, 10, marker='o', color='orange')
+
+    # annotate
+    ax.set_ylabel('head')
+    ax.set_xlabel('tail')
+
+    # show the figure
+    if show:  # pragma: no cover
+        fig.show()
+
+    return fig
+
+
+def plotly_variogram_scattergram(variogram, fig=None, show=True):
+    # get the plot data
+    tail, head = __calculate_plot_data(variogram)
+
+    # create a new Figure if needed
+    if fig is None:
+        fig = go.Figure()
+
+    # add vertical and horizontal lines
+    try:
+        fig.add_vline(x=np.mean(tail), line_dash='dash', line_width=2, line_color='red')
+        fig.add_hline(y=np.mean(head), line_dash='dash', line_width=2, line_color='red')
+    except AttributeError:
+        # add_hline and add_vline were added in plotly >= 4.12
+        print("Can't plot lines, consider updating your plotly to >= 4.12")
+        pass
+
+    # do the plot
+    fig.add_trace(
+        go.Scattergl(x=tail, y=head, mode='markers', marker=dict(color='orange'))
+    )
+
+    # add some titles
+    fig.update_xaxes(title_text='Tail')
+    fig.update_yaxes(title_text='Head')
+
+    if show:
+        fig.show()
+
+    return fig

--- a/skgstat/tests/test_plotting_backend.py
+++ b/skgstat/tests/test_plotting_backend.py
@@ -1,0 +1,31 @@
+import pytest
+from skgstat.plotting import backend
+
+
+def test_backend_no_args():
+    """
+    The default backend should be 'matplotlib'
+    """
+    assert backend() == 'matplotlib'
+
+
+@pytest.mark.depends(on=['test_backend_no_args'])
+def test_raise_value_error():
+    """
+    Raise a value error by setting the wrong backend
+    """
+    with pytest.raises(ValueError):
+        backend('not-a-backend')
+
+
+@pytest.mark.depends(on=['test_raise_value_error'])
+def test_change_plotting_backend():
+    """
+    Set the correct backend and check
+    """
+    # change to plotly
+    backend('plotly')
+    assert backend() == 'plotly'
+
+    # change back
+    backend('matplotlib')

--- a/skgstat/tests/test_plotting_backend.py
+++ b/skgstat/tests/test_plotting_backend.py
@@ -1,6 +1,9 @@
 import pytest
 from skgstat.plotting import backend
 
+import matplotlib.pyplot as plt
+import plotly.graph_objects as go 
+
 
 def test_backend_no_args():
     """

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -7,8 +7,16 @@ import pandas as pd
 from numpy.testing import assert_array_almost_equal
 import matplotlib.pyplot as plt
 
+try:
+    import plotly.graph_objects as go
+    PLOTLY_FOUND = True
+except ImportError:
+    print('No plotly installed. Skip plot tests')
+    PLOTLY_FOUND = False
+
 from skgstat import Variogram
 from skgstat import estimators
+from skgstat import plotting
 
 
 class TestVariogramInstatiation(unittest.TestCase):
@@ -862,6 +870,77 @@ class TestVariogramPlots(unittest.TestCase):
             len(fig1.axes[0].get_children()),
             len(fig2.axes[0].get_children()) - 1
         )
+
+
+class TestVariogramPlotlyPlots(unittest.TestCase):
+    def setUp(self):
+        # set up default values, whenever c and v are not important
+        np.random.seed(42)
+        self.c = np.random.gamma(10, 4, (150, 2))
+        np.random.seed(42)
+        self.v = np.random.normal(10, 4, 150)
+        self.V = Variogram(self.c, self.v)
+
+    def test_plotly_main_plot(self):
+        if PLOTLY_FOUND:
+            # switch to plotly
+            plotting.backend('plotly')
+
+            self.assertTrue(
+                isinstance(self.V.plot(show=False), go.Figure)
+            )
+
+            plotting.backend('matplotlib')
+
+    def test_plotly_scattergram(self):
+        if PLOTLY_FOUND:
+            # switch to plotly
+            plotting.backend('plotly')
+
+            self.assertTrue(
+                isinstance(self.V.scattergram(show=False), go.Figure)
+            )
+
+            plotting.backend('matplotlib')
+
+    def test_plotly_location_trend(self):
+        if PLOTLY_FOUND:
+            # switch to plotly
+            plotting.backend('plotly')
+
+            self.assertTrue(
+                isinstance(self.V.location_trend(show=False), go.Figure)
+            )
+
+            plotting.backend('matplotlib')
+
+    def test_plotly_dd_plot(self):
+        if PLOTLY_FOUND:
+            # switch to plotly
+            plotting.backend('plotly')
+
+            self.assertTrue(
+                isinstance(self.V.distance_difference_plot(show=False), go.Figure)
+            )
+
+            plotting.backend('matplotlib')
+    
+    def test_undefined_backend(self):
+        # force the backend into an undefined state
+        import skgstat
+        skgstat.__backend__ = 'not-a-backend'
+
+        for fname in ('plot', 'scattergram', 'location_trend', 'distance_difference_plot'):
+            with self.assertRaises(ValueError) as e:
+                self.V.plot()
+
+                self.assertEqual(
+                    str(e.exception),
+                    'The plotting backend has an undefined state.'
+                )
+        
+        # make the backend valid again
+        skgstat.__backend__ = 'matplotlib'
 
 
 class TestVariogramPickling(unittest.TestCase):


### PR DESCRIPTION
With this PR, it has become possible to use [plotly](https://plotly.com/python/) instead of matplotlib for plotting. These plot objects integrate much better in web-driven applications using `scikit-gstat`.

The new sub-module `skgstat.plotting` has a function to switch backends:

```python
from skgstat import plotting

plotting.backend('plotly')
[...]

Vargriogram.plot()
```

plotly is **not** added as a dependency, so it has to be installed manually. The new code didn't change any existing behavior and  `skgstat` can be used just like before.

At the current state, `skgstat` does not make use of the most powerful features of plotly, as I am just porting the existing plots to plotly. This will be a focus of future developments, to make more of plotly's (and also matplotlib's) features and customizations available.

@redhog , I will add a demo notebook as quick as possible and then I'm curious to hear your thoughts on this.