### PR TITLE
Extending `describe` output

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,9 @@ Version 0.3.7
   of the class. As of Version `0.3.7` this is used to pass arguments down to the 
   :func:`entropy <skgstat.estimators.entropy>` and :func:`percentile <skgstat.percentile.entropy>` 
   estimators.
+- [Variogram] the `describe <skgstat.Variogram.describe>` now adds the 
+  `init <skgstat.Variogram.__init__>` arguments by default to the output. The method can output 
+  the init params as a nested dict inside the output or flatten the output dict.
 
 Version 0.3.6
 =============

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -872,6 +872,29 @@ class TestVariogramPlots(unittest.TestCase):
             len(fig2.axes[0].get_children()) - 1
         )
 
+    def test_variogram_default_describe(self):
+        V = Variogram(self.c, self.v)
+
+        desc = V.describe()
+        self.assertTrue('params' in desc.keys())
+        self.assertTrue('kwargs' in desc.keys())
+
+    def test_variogram_describe_short(self):
+        V = Variogram(self.c, self.v)
+
+        desc = V.describe(short=True)
+        self.assertFalse('params' in desc.keys())
+        self.assertFalse('kwargs' in desc.keys())
+
+
+    def test_variogram_describe_flat(self):
+        V = Variogram(self.c, self.v)
+
+        desc = V.describe(flat=True)
+
+        # test there are no nested dicts
+        self.assertTrue(all([not isinstance(v, dict) for v in desc.values()]))
+
 
 class TestVariogramPlotlyPlots(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
@redhog  this PR extends the output of `Variogram.describe` as discussed in #63. Will therefore also close #63. 

The  `Variogram.describe` now takes two arguments, `short=False` and `flat=False`. If `short` is true, the new output will be suppressed and the method returns the old output. If `False`(default), the output will have a `'params'` and a `'kwargs'` key containing the `__init__` arguments and the `**kwargs` given to `__init__`. 
With `flat=True`, the two new nested `dict` will *update* the output, instead of extending it, resulting in a flat dictionary.

@redhog, I decided to implement this myself, as I need this functionality, as well. Hope this serves your needs as well. Let me know, if I can merge or if you need any changes.
Best
Mirko   