### PR TITLE
Extend available binning functions

### DIFF
--- a/docs/reference/directionalvariogram.rst
+++ b/docs/reference/directionalvariogram.rst
@@ -6,10 +6,6 @@ DirectionalVariogram Class
     :members:
 
     .. automethod:: __init__
-    .. automethod:: azimuth
-    .. automethod:: tolerance
-    .. automethod:: bandwidth
-    .. automethod:: pair_field
     .. automethod:: _calc_direction_mask_data
     .. automethod:: _triangle
     .. automethod:: _compass

--- a/skgstat/DirectionalVariogram.py
+++ b/skgstat/DirectionalVariogram.py
@@ -2,9 +2,7 @@
 Directional Variogram
 """
 import numpy as np
-import matplotlib.pyplot as plt
-from scipy.spatial.distance import squareform, pdist
-import matplotlib.collections
+from scipy.spatial.distance import pdist
 
 from .Variogram import Variogram
 from skgstat import plotting
@@ -95,19 +93,18 @@ class DirectionalVariogram(Variogram):
         bin_func : str
             .. versionchanged:: 0.3.8
                 added 'fd', 'sturges', 'scott', 'sqrt', 'doane'
+            
             String identifying the binning function used to find lag class
             edges. All methods calculate bin edges on the interval [0, maxlag[.
             Possible values are:
-
-            * `'even'` (default) finds `n_lags` same width bins
-            * `'uniform'` forms `n_lags` bins of same data count
-            * `'fd'` applies Freedman-Diaconis estimator to find `n_lags`
-            * `'sturges'` applies Sturge's rule to find `n_lags`.
-            * `'scott'` applies Scott's rule to find `n_lags`
-            * `'doane'` applies Doane's extension to Sturge's rule to
-                find `n_lags`
-            * `'sqrt'` uses the square-root of :func:`distance <skgstat.Variogram.distance>` 
-                as `n_lags`.
+            
+                * `'even'` (default) finds `n_lags` same width bins
+                * `'uniform'` forms `n_lags` bins of same data count
+                * `'fd'` applies Freedman-Diaconis estimator to find `n_lags`
+                * `'sturges'` applies Sturge's rule to find `n_lags`.
+                * `'scott'` applies Scott's rule to find `n_lags`
+                * `'doane'` applies Doane's extension to Sturge's rule to find `n_lags`
+                * `'sqrt'` uses the square-root of :func:`distance <skgstat.Variogram.distance>`. as `n_lags`.
 
             More details are given in the documentation for :func:`set_bin_func <skgstat.Variogram.set_bin_func>`.
         normalize : bool
@@ -209,12 +206,14 @@ class DirectionalVariogram(Variogram):
         -----------------
         entropy_bins : int, str
             .. versionadded:: 0.3.7
+
             If the `estimator <skgstat.Variogram.estimator>` is set to
             `'entropy'` this argument sets the number of bins, that should be
             used for histogram calculation.
         percentile : int
             .. versionadded:: 0.3.7
-            If the `estimator <skgstat.Variogram.estimator>` is set to 
+            
+            If the `estimator <skgstat.Variogram.estimator>` is set to
             `'entropy'` this argument sets the percentile to be used.
 
         """

--- a/skgstat/DirectionalVariogram.py
+++ b/skgstat/DirectionalVariogram.py
@@ -538,7 +538,7 @@ class DirectionalVariogram(Variogram):
             d = self.distance.copy()
             d[np.where(~self._direction_mask())] = np.nan
 
-            self._bins, n = self.bin_func(d, self.n_lags, self.maxlag)
+            self._bins, n = self.bin_func(d, self._n_lags, self.maxlag)
 
             # if the binning function returned an N, the n_lags need
             # to be adjusted directly (not through the setter)

--- a/skgstat/DirectionalVariogram.py
+++ b/skgstat/DirectionalVariogram.py
@@ -93,12 +93,23 @@ class DirectionalVariogram(Variogram):
             passed through to pdist. These are accepted by pdist for some of
             the metrics. In these cases the default values are used.
         bin_func : str
+            .. versionchanged:: 0.3.8
+                added 'fd', 'sturges', 'scott', 'sqrt', 'doane'
             String identifying the binning function used to find lag class
-            edges. At the moment there are two possible values: 'even'
-            (default) or 'uniform'. Even will find n_lags bins of same width
-            in the interval [0,maxlag[. 'uniform' will identfy n_lags bins on
-            the same interval, but with varying edges so that all bins count
-            the same amount of observations.
+            edges. All methods calculate bin edges on the interval [0, maxlag[.
+            Possible values are:
+
+            * `'even'` (default) finds `n_lags` same width bins
+            * `'uniform'` forms `n_lags` bins of same data count
+            * `'fd'` applies Freedman-Diaconis estimator to find `n_lags`
+            * `'sturges'` applies Sturge's rule to find `n_lags`.
+            * `'scott'` applies Scott's rule to find `n_lags`
+            * `'doane'` applies Doane's extension to Sturge's rule to
+                find `n_lags`
+            * `'sqrt'` uses the square-root of :func:`distance <skgstat.Variogram.distance>` 
+                as `n_lags`.
+
+            More details are given in the documentation for :func:`set_bin_func <skgstat.Variogram.set_bin_func>`.
         normalize : bool
             Defaults to False. If True, the independent and dependent
             variable will be normalized to the range [0,1].

--- a/skgstat/DirectionalVariogram.py
+++ b/skgstat/DirectionalVariogram.py
@@ -538,7 +538,12 @@ class DirectionalVariogram(Variogram):
             d = self.distance.copy()
             d[np.where(~self._direction_mask())] = np.nan
 
-            self._bins = self.bin_func(d, self.n_lags, self.maxlag)
+            self._bins, n = self.bin_func(d, self.n_lags, self.maxlag)
+
+            # if the binning function returned an N, the n_lags need
+            # to be adjusted directly (not through the setter)
+            if n is not None:
+                self._n_lags = n
 
         return self._bins.copy()
 

--- a/skgstat/SpaceTimeVariogram.py
+++ b/skgstat/SpaceTimeVariogram.py
@@ -307,6 +307,8 @@ class SpaceTimeVariogram:
 
     @property
     def x_lags(self):
+        if self._x_lags is None:
+            self._x_lags = len(self.xbins)
         return self._x_lags
 
     @x_lags.setter
@@ -331,8 +333,10 @@ class SpaceTimeVariogram:
                 return self.values.shape[1] - 1
             else:
                 raise ValueError("Only 'max' supported as string argument.")
-        else:
-            return self._t_lags
+        elif self._t_lags is None:
+            self._t_lags = len(self.tbins)
+        
+        return self._t_lags
 
     @t_lags.setter
     def t_lags(self, lags):
@@ -400,6 +404,7 @@ class SpaceTimeVariogram:
         skgstat.binning.uniform_count_lags
 
         """
+        adjust_n_lags = False
         # switch the function
         if bin_func.lower() == 'even':
             f = binning.even_width_lags
@@ -409,8 +414,9 @@ class SpaceTimeVariogram:
             # define a wrapper to pass the name
             def wrapper(distances, n, maxlag):
                 return binning.auto_derived_lags(distances, bin_func.lower(), maxlag)
-            
+
             f = wrapper
+            adjust_n_lags = True
         else:
             raise ValueError('%s binning method is not known' % bin_func)
 
@@ -418,6 +424,9 @@ class SpaceTimeVariogram:
         if axis.lower() == 'space' or axis.lower() == 's':
             self._xbin_func = f
             self._xbin_func_name = bin_func
+
+            if adjust_n_lags:
+                self._x_lags = None
 
             # update marginal
             self._set_xmarg_params()
@@ -429,6 +438,9 @@ class SpaceTimeVariogram:
         elif axis.lower() == 'time' or axis.lower() == 't':
             self._tbin_func = f
             self._tbin_func_name = bin_func
+
+            if adjust_n_lags:
+                self._t_lags = None
 
             # update marignal
             self._set_tmarg_params()
@@ -459,7 +471,7 @@ class SpaceTimeVariogram:
         """
         # check if cached
         if self._xbins is None:
-            self._xbins, n = self._xbin_func(self.xdistance, self.x_lags, self.maxlag)
+            self._xbins, n = self._xbin_func(self.xdistance, self._x_lags, self.maxlag)
 
             # if n is not None, the binning func overwrote it
             if n is not None:
@@ -501,7 +513,9 @@ class SpaceTimeVariogram:
 
         """
         if self._tbins is None:
-            self._tbins, n = self._tbin_func(self.tdistance, self.t_lags, None)
+            # this is a bit dumb, but we cannot pass a string as n param
+            tn = self._t_lags if self._t_lags != 'max' else self.t_lags
+            self._tbins, n = self._tbin_func(self.tdistance, tn, None)
 
             # if n is not None, the binning func overwote it
             if n is not None:

--- a/skgstat/SpaceTimeVariogram.py
+++ b/skgstat/SpaceTimeVariogram.py
@@ -405,6 +405,12 @@ class SpaceTimeVariogram:
             f = binning.even_width_lags
         elif bin_func.lower() == 'uniform':
             f = binning.uniform_count_lags
+        elif isinstance(bin_func, str):
+            # define a wrapper to pass the name
+            def wrapper(distances, n, maxlag):
+                return binning.auto_derived_lags(distances, bin_func.lower(), maxlag)
+            
+            f = wrapper
         else:
             raise ValueError('%s binning method is not known' % bin_func)
 
@@ -419,6 +425,7 @@ class SpaceTimeVariogram:
             # reset
             self._xgroups = None
             self._xbins = None
+
         elif axis.lower() == 'time' or axis.lower() == 't':
             self._tbin_func = f
             self._tbin_func_name = bin_func
@@ -429,6 +436,7 @@ class SpaceTimeVariogram:
             # reset
             self._tgroups = None
             self._tbins = None
+
         else:
             raise ValueError('%s is not a valid axis' % axis)
 
@@ -451,8 +459,12 @@ class SpaceTimeVariogram:
         """
         # check if cached
         if self._xbins is None:
-            self._xbins = self._xbin_func(self.xdistance,
-                                          self.x_lags, self.maxlag)
+            self._xbins, n = self._xbin_func(self.xdistance, self.x_lags, self.maxlag)
+
+            # if n is not None, the binning func overwrote it
+            if n is not None:
+                self._x_lags = n
+
         return self._xbins
 
     @xbins.setter
@@ -489,7 +501,11 @@ class SpaceTimeVariogram:
 
         """
         if self._tbins is None:
-            self._tbins = self._tbin_func(self.tdistance, self.t_lags, None)
+            self._tbins, n = self._tbin_func(self.tdistance, self.t_lags, None)
+
+            # if n is not None, the binning func overwote it
+            if n is not None:
+                self._t_lags = n
 
         return self._tbins
 

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -431,9 +431,9 @@ class Variogram(object):
             * `'doane'` estimates the number of evenly distributed lag classes
                 using Doane's extension to Sturge's rule [104]_:
                 .. math::
-                n = 1 + \log_{2}(n) + \log_{2}(1 + \frac{|g_1|}{\sigma_{g}})
-                g = E[(\frac{x - \mu}{\sigma})^3]
-                \sigma_{g} = \sqrt{\frac{6(n - 2)}{(n + 1)(n + 3)}}
+                    n = 1 + \log_{2}(n) + \log_{2}(1 + \frac{|g_1|}{\sigma_{g}})
+                    g = E[(\frac{x - \mu}{\sigma})^3]
+                    \sigma_{g} = \sqrt{\frac{6(n - 2)}{(n + 1)(n + 3)}}
 
         Returns
         -------

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -431,9 +431,9 @@ class Variogram(object):
             * `'doane'` estimates the number of evenly distributed lag classes
                 using Doane's extension to Sturge's rule [104]_:
                 .. math::
-                    n = 1 + \log_{2}(n) + \log_{2}(1 + \frac{|g_1|}{\sigma_{g}})
+                    n = 1 + \log_{2}(n) + \log_2(1 + \frac{|g|}{\sigma})
                     g = E[(\frac{x - \mu}{\sigma})^3]
-                    \sigma_{g} = \sqrt{\frac{6(n - 2)}{(n + 1)(n + 3)}}
+                    \sigma = \sqrt{\frac{6(n - 2)}{(n + 1)(n + 3)}}
 
         Returns
         -------

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -93,12 +93,23 @@ class Variogram(object):
             passed through to pdist. These are accepted by pdist for some of
             the metrics. In these cases the default values are used.
         bin_func : str
+            .. versionchanged:: 0.3.8
+                added 'fd', 'sturges', 'scott', 'sqrt', 'doane'
             String identifying the binning function used to find lag class
-            edges. At the moment there are two possible values: 'even'
-            (default) or 'uniform'. Even will find n_lags bins of same width
-            in the interval [0,maxlag[. 'uniform' will identfy n_lags bins on
-            the same interval, but with varying edges so that all bins count
-            the same amount of observations.
+            edges. All methods calculate bin edges on the interval [0, maxlag[.
+            Possible values are:
+
+            * `'even'` (default) finds `n_lags` same width bins
+            * `'uniform'` forms `n_lags` bins of same data count
+            * `'fd'` applies Freedman-Diaconis estimator to find `n_lags`
+            * `'sturges'` applies Sturge's rule to find `n_lags`.
+            * `'scott'` applies Scott's rule to find `n_lags`
+            * `'doane'` applies Doane's extension to Sturge's rule to
+                find `n_lags`
+            * `'sqrt'` uses the square-root of :func:`distance <skgstat.Variogram.distance>` 
+                as `n_lags`.
+
+            More details are given in the documentation for :func:`set_bin_func <skgstat.Variogram.set_bin_func>`.
         normalize : bool
             Defaults to False. If True, the independent and dependent
             variable will be normalized to the range [0,1].
@@ -378,22 +389,51 @@ class Variogram(object):
         self.set_bin_func(bin_func=bin_func)
 
     def set_bin_func(self, bin_func: str):
-        """Set binning function
+        r"""Set binning function
 
         Sets a new binning function to be used. The new binning method is set
         by a string identifying the new function to be used. Can be one of:
-        ['even', 'uniform'].
+        ['even', 'uniform', 'fd', 'sturges', 'scott', 'sqrt', 'doane'].
+        If the number of lag classes should be estimated automatically, it is 
+        recommended to use ' sturges' for small, normal distributed locations
+        and 'fd' or 'scott' for large datasets, where 'fd' is more robust to
+        outliers. 'sqrt' is by far the fastest estimator. 'doane' is an 
+        extension of Sturge's rule for non-normal distributed data.
+
+        .. versionchanged:: 0.3.8
+            added 'fd', 'sturges', 'scott', 'sqrt', 'doane'
 
         Parameters
         ----------
         bin_func : str
             Can be one of:
 
-            * **'even'**: Use skgstat.binning.even_width_lags for using
-              n_lags lags of equal width up to maxlag.
-            * **'uniform'**: Use skgstat.binning.uniform_count_lags for using
-              n_lags lags up to maxlag in which the pairwise differences
-              follow a uniform distribution.
+            * `'even'`: Use skgstat.binning.even_width_lags for using
+                n_lags lags of equal width up to maxlag.
+            * `'uniform'`: Use skgstat.binning.uniform_count_lags for using
+                n_lags lags up to maxlag in which the pairwise differences
+                follow a uniform distribution.
+            * `'sturges'` estimates the number of evenly distributed lag
+                classes (n) by Sturges rule [101]_:
+                .. math::
+                    n = log_2 n + 1
+            * `'scott'` estimates the lag class widths (h) by
+                Scott's rule [102]_:
+                .. math::
+                    h = \sigma \frac{24 * \sqrt{\pi}}{n}^{\frac{1}{3}}
+            * `'sqrt'` estimates the number of lags (n) by the suare-root:
+                .. math::
+                    n = \sqrt{n}
+            * `'fd'` estimates the lag class widths (h) using the
+                Freedman Diaconis estimator [103]_:
+                .. math::
+                    h = 2\frac{IQR}{n^{1/3}}
+            * `'doane'` estimates the number of evenly distributed lag classes
+                using Doane's extension to Sturge's rule [104]_:
+                .. math::
+                n = 1 + \log_{2}(n) + \log_{2}(1 + \frac{|g_1|}{\sigma_{g}})
+                g = E[(\frac{x - \mu}{\sigma})^3]
+                \sigma_{g} = \sqrt{\frac{6(n - 2)}{(n + 1)(n + 3)}}
 
         Returns
         -------
@@ -404,6 +444,19 @@ class Variogram(object):
         Variogram.bin_func
         skgstat.binning.uniform_count_lags
         skgstat.binning.even_width_lags
+        skgstat.binning.auto_derived_lags
+
+        References
+        ----------
+        .. [101] Scott, D.W. (2009), Sturges' rule. WIREs Comp Stat, 1: 303-306. 
+            https://doi.org/10.1002/wics.35
+        .. [102] Scott, D.W. (2010), Scott's rule. WIREs Comp Stat, 2: 497-502. 
+            https://doi.org/10.1002/wics.103
+        .. [103] Freedman, David, and Persi Diaconis  (1981), "On the histogram as 
+            a density estimator: L 2 theory." Zeitschrift für Wahrscheinlichkeitstheorie 
+            und verwandte Gebiete 57.4: 453-476.
+        .. [104] Doane, D. P. (1976). Aesthetic frequency classifications. 
+            The American Statistician, 30(4), 181-183.
 
         """
         # switch the input
@@ -418,8 +471,11 @@ class Variogram(object):
 
             self._bin_func = wrapper
             self._n_lags = None
+        elif callable(bin_func):
+            self._bin_func = bin_func
+            bin_func = 'custom'
         else:
-            raise ValueError('%s binning method is not known' % bin_func)
+            raise AttributeError('bin_func has to be of type string.')
 
         # store the name
         self._bin_func_name = bin_func

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -92,24 +92,24 @@ class Variogram(object):
             scipy.spatial.distance.pdist. Additional parameters are not (yet)
             passed through to pdist. These are accepted by pdist for some of
             the metrics. In these cases the default values are used.
-        bin_func : str
+        bin_func : str            
             .. versionchanged:: 0.3.8
                 added 'fd', 'sturges', 'scott', 'sqrt', 'doane'
+
             String identifying the binning function used to find lag class
             edges. All methods calculate bin edges on the interval [0, maxlag[.
             Possible values are:
 
-            * `'even'` (default) finds `n_lags` same width bins
-            * `'uniform'` forms `n_lags` bins of same data count
-            * `'fd'` applies Freedman-Diaconis estimator to find `n_lags`
-            * `'sturges'` applies Sturge's rule to find `n_lags`.
-            * `'scott'` applies Scott's rule to find `n_lags`
-            * `'doane'` applies Doane's extension to Sturge's rule to
-                find `n_lags`
-            * `'sqrt'` uses the square-root of :func:`distance <skgstat.Variogram.distance>` 
-                as `n_lags`.
+                * `'even'` (default) finds `n_lags` same width bins
+                * `'uniform'` forms `n_lags` bins of same data count
+                * `'fd'` applies Freedman-Diaconis estimator to find `n_lags`
+                * `'sturges'` applies Sturge's rule to find `n_lags`.
+                * `'scott'` applies Scott's rule to find `n_lags`
+                * `'doane'` applies Doane's extension to Sturge's rule to find `n_lags`
+                * `'sqrt'` uses the square-root of :func:`distance <skgstat.Variogram.distance>` as `n_lags`.
 
             More details are given in the documentation for :func:`set_bin_func <skgstat.Variogram.set_bin_func>`.
+
         normalize : bool
             Defaults to False. If True, the independent and dependent
             variable will be normalized to the range [0,1].
@@ -167,11 +167,13 @@ class Variogram(object):
         -----------------
         entropy_bins : int, str
             .. versionadded:: 0.3.7
+
             If the `estimator <skgstat.Variogram.estimator>` is set to
             `'entropy'` this argument sets the number of bins, that should be
             used for histogram calculation.
         percentile : int
             .. versionadded:: 0.3.7
+
             If the `estimator <skgstat.Variogram.estimator>` is set to 
             `'entropy'` this argument sets the percentile to be used.
 
@@ -408,36 +410,56 @@ class Variogram(object):
         bin_func : str
             Can be one of:
 
-            * `'even'`: Use skgstat.binning.even_width_lags for using
-                n_lags lags of equal width up to maxlag.
-            * `'uniform'`: Use skgstat.binning.uniform_count_lags for using
-                n_lags lags up to maxlag in which the pairwise differences
-                follow a uniform distribution.
-            * `'sturges'` estimates the number of evenly distributed lag
-                classes (n) by Sturges rule [101]_:
-                .. math::
-                    n = log_2 n + 1
-            * `'scott'` estimates the lag class widths (h) by
-                Scott's rule [102]_:
-                .. math::
-                    h = \sigma \frac{24 * \sqrt{\pi}}{n}^{\frac{1}{3}}
-            * `'sqrt'` estimates the number of lags (n) by the suare-root:
-                .. math::
-                    n = \sqrt{n}
-            * `'fd'` estimates the lag class widths (h) using the
-                Freedman Diaconis estimator [103]_:
-                .. math::
-                    h = 2\frac{IQR}{n^{1/3}}
-            * `'doane'` estimates the number of evenly distributed lag classes
-                using Doane's extension to Sturge's rule [104]_:
-                .. math::
-                    n = 1 + \log_{2}(n) + \log_2(1 + \frac{|g|}{\sigma})
-                    g = E[(\frac{x - \mu}{\sigma})^3]
-                    \sigma = \sqrt{\frac{6(n - 2)}{(n + 1)(n + 3)}}
+                * 'even'
+                * 'uniform'
+                * 'fd'
+                * 'sturges'
+                * 'scott'
+                * 'sqrt'
+                * 'doane'
 
         Returns
         -------
         void
+
+        Notes
+        -----
+        **`'even'`**: Use skgstat.binning.even_width_lags for using
+        n_lags lags of equal width up to maxlag.
+
+        **`'uniform'`**: Use skgstat.binning.uniform_count_lags for using
+        n_lags lags up to maxlag in which the pairwise differences
+        follow a uniform distribution.
+
+        **`'sturges'`**: estimates the number of evenly distributed lag
+        classes (n) by Sturges rule [101]_:
+
+        .. math::
+            n = log_2 n + 1
+
+        **`'scott'`**: estimates the lag class widths (h) by Scott's rule [102]_:
+
+        .. math::
+            h = \sigma \frac{24 * \sqrt{\pi}}{n}^{\frac{1}{3}}
+
+        **`'sqrt'`**: estimates the number of lags (n) by the suare-root:
+
+        .. math::
+            n = \sqrt{n}
+
+        **`'fd'`**: estimates the lag class widths (h) using the
+        Freedman Diaconis estimator [103]_:
+
+        .. math::
+            h = 2\frac{IQR}{n^{1/3}}
+
+        **`'doane'`**: estimates the number of evenly distributed lag classes
+        using Doane's extension to Sturge's rule [104]_:
+
+        .. math::
+            n = 1 + \log_{2}(n) + \log_2(1 + \frac{|g|}{\sigma})
+            g = E[(\frac{x - \mu}{\sigma})^3]
+            \sigma = \sqrt{\frac{6(n - 2)}{(n + 1)(n + 3)}}
 
         See Also
         --------
@@ -1828,16 +1850,21 @@ class Variogram(object):
         -----------------
         add_trend_line : bool
             .. versionadded:: 0.3.5
+
             If set to `True`, the class will fit a linear model to each
             coordinate dimension and output the model along with a
             calculated R². With high R² values, you should consider
             rejecting the input data, or transforming it.
+
             .. note::
                 Right now, this is only supported for ``'plotly'`` backend
+   
 
         Returns
         -------
-        matplotlib.Figure, plotly.graph_objects.Figure
+        fig : matplotlib.Figure, plotly.graph_objects.Figure
+            The figure produced by the function. Dependends on the 
+            current backend.
 
         """
         # get the backend

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -417,6 +417,7 @@ class Variogram(object):
                 return binning.auto_derived_lags(distances, bin_func.lower(), maxlag)
 
             self._bin_func = wrapper
+            self._n_lags = None
         else:
             raise ValueError('%s binning method is not known' % bin_func)
 
@@ -441,7 +442,7 @@ class Variogram(object):
     def bins(self):
         # if bins are not calculated, do it
         if self._bins is None:
-            self._bins, n = self.bin_func(self.distance, self.n_lags, self.maxlag)
+            self._bins, n = self.bin_func(self.distance, self._n_lags, self.maxlag)
 
             # if the binning function returned an N, the n_lags need
             # to be adjusted directly (not through the setter)
@@ -469,6 +470,8 @@ class Variogram(object):
         the grouping index and fitting parameters
 
         """
+        if self._n_lags is None:
+            self._n_lags = len(self.bins)
         return self._n_lags
 
     @n_lags.setter

--- a/skgstat/binning.py
+++ b/skgstat/binning.py
@@ -10,22 +10,24 @@ def even_width_lags(distances, n, maxlag):
     Parameters
     ----------
     distances : numpy.array
-        Flat numpy array representing the upper triangle of the distance matrix.
-    n: integer
+        Flat numpy array representing the upper triangle of
+        the distance matrix.
+    n : integer
         Amount of lag classes to find
     maxlag : integer, float
         Limit the last lag class to this separating distance.
 
     Returns
     -------
-    numpy.array
+    bin_edges : numpy.ndarray
+        The **upper** bin edges of the lag classes
 
     """
     # maxlags larger than the maximum separating distance will be ignored
     if maxlag is None or maxlag > np.nanmax(distances):
         maxlag = np.nanmax(distances)
 
-    return np.linspace(0, maxlag, n + 1)[1:]
+    return np.linspace(0, maxlag, n + 1)[1:], None
 
 
 def uniform_count_lags(distances, n, maxlag):
@@ -37,15 +39,17 @@ def uniform_count_lags(distances, n, maxlag):
     Parameters
     ----------
     distances : numpy.array
-        Flat numpy array representing the upper triangle of the distance matrix.
-    n: integer
+        Flat numpy array representing the upper triangle of
+        the distance matrix.
+    n : integer
         Amount of lag classes to find
     maxlag : integer, float
         Limit the last lag class to this separating distance.
 
     Returns
     -------
-    numpy.array
+    bin_edges : numpy.ndarray
+        The **upper** bin edges of the lag classes
 
     """
     # maxlags larger than the maximum separating distance will be ignored
@@ -58,4 +62,47 @@ def uniform_count_lags(distances, n, maxlag):
     return np.fromiter(
         (np.nanpercentile(d, (i / n) * 100) for i in range(1, n + 1)),
         dtype=float
-    )
+    ), None
+
+
+def auto_derived_lags(distances, method_name, maxlag):
+    """Derive bins automatically
+    .. vserionadded:: 0.3.8
+
+    Uses `histogram_bin_edges <numpy.histogram_bin_edges>` to derive the
+    lag classes automatically. Supports any method supported by
+    `histogram_bin_edges <numpy.histogram_bin_edges>`. It is recommended
+    to use `'stuges'`, `'doane'` or `'fd'`.
+
+    Parameters
+    ----------
+    distances : numpy.array
+        Flat numpy array representing the upper triangle of
+        the distance matrix.
+    maxlag : integer, float
+        Limit the last lag class to this separating distance.
+    method_name : str
+        Any method supported by
+        `histogram_bin_edges <numpy.histogram_bin_edges>`
+
+    Returns
+    -------
+    bin_edges : numpy.ndarray
+        The **upper** bin edges of the lag classes
+
+    See Also
+    --------
+    numpy.histogram_bin_edges
+
+    """
+    # maxlags largher than maximum separating distance will be ignored
+    if maxlag is None or maxlag > np.nanmax(distances):
+        maxlag = np.nanmax(distances)
+
+    # filter for distances < maxlag
+    d = distances[np.where(distances <= maxlag)]
+
+    # calculate the edges
+    edges = np.histogram_bin_edges(d, bins=method_name)[1:]
+
+    return edges, len(edges)

--- a/skgstat/binning.py
+++ b/skgstat/binning.py
@@ -7,6 +7,10 @@ def even_width_lags(distances, n, maxlag):
     Calculate the lag edges for a given amount of bins using the same lag
     step width for all bins.
 
+    .. versionchanged:: 0.3.8
+        Function returns `None` as second value to indicate that
+        The number of lag classes was not changed
+
     Parameters
     ----------
     distances : numpy.array
@@ -35,6 +39,10 @@ def uniform_count_lags(distances, n, maxlag):
 
     Calculate the lag edges for a given amount of bins with the same amount
     of observations in each lag class. The lag step width will be variable.
+
+    .. versionchanged:: 0.3.8
+        Function returns `None` as second value to indicate that
+        The number of lag classes was not changed
 
     Parameters
     ----------

--- a/skgstat/tests/test_binning.py
+++ b/skgstat/tests/test_binning.py
@@ -3,23 +3,28 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-from skgstat.binning import even_width_lags, uniform_count_lags
+from skgstat.binning import even_width_lags, uniform_count_lags, auto_derived_lags
 
 
 class TestEvenWidth(unittest.TestCase):
     @staticmethod
     def test_normal():
         np.random.seed(42)
+        bins, _ = even_width_lags(np.random.normal(5, 1, 1000), 4, None)
+        
         assert_array_almost_equal(
-            even_width_lags(np.random.normal(5, 1, 1000), 4, None),
+            bins,
             np.array([2.21318287, 4.42636575, 6.63954862, 8.85273149])
         )
 
     @staticmethod
     def test_more_bins():
         np.random.seed(42)
+        
+        bins, _ = even_width_lags(np.random.normal(5, 1, 1000), 10, None)
+        
         assert_array_almost_equal(
-            even_width_lags(np.random.normal(5, 1, 1000), 10, None),
+            bins,
             np.array([0.88527315, 1.7705463, 2.65581945, 3.5410926, 4.42636575,
                       5.3116388, 6.19691204, 7.08218519, 7.96745834, 8.8527314])
         )
@@ -27,24 +32,29 @@ class TestEvenWidth(unittest.TestCase):
     @staticmethod
     def test_maxlag():
         np.random.seed(42)
+        bins, _ = even_width_lags(np.random.normal(5, 1, 1000), 4, 4.4)
+        
         assert_array_almost_equal(
-            even_width_lags(np.random.normal(5, 1, 1000), 4, 4.4),
+            bins,
             np.array([1.1, 2.2, 3.3, 4.4])
         )
 
     @staticmethod
     def test_too_large_maxlag():
         np.random.seed(42)
+
+        bins, n = even_width_lags(np.random.normal(5, 1, 1000), 4, 400)
         assert_array_almost_equal(
-            even_width_lags(np.random.normal(5, 1, 1000), 4, 400),
+            bins,
             np.array([2.21318287, 4.42636575, 6.63954862, 8.85273149])
         )
 
     @staticmethod
     def test_median_split():
         np.random.seed(42)
+        bins, _ = even_width_lags(np.random.normal(5, 1, 1000), 2, None)
         assert_array_almost_equal(
-            even_width_lags(np.random.normal(5, 1, 1000), 2, None),
+            bins,
             np.array([4.42636575, 8.85273149])
         )
 
@@ -52,14 +62,43 @@ class TestEvenWidth(unittest.TestCase):
 class TestUniformCount(unittest.TestCase):
     def test_normal(self):
         np.random.seed(42)
+
+        bins, _ = uniform_count_lags(np.random.normal(10, 2, 1000), 4, None)
         assert_array_almost_equal(
-            uniform_count_lags(np.random.normal(10, 2, 1000), 4, None),
+            bins,
             np.array([8.7048, 10.0506, 11.2959, 17.7055]),
             decimal=4
         )
 
-# TODO: put the other test for binning here
 
+class TestDerivedBins(unittest.TestCase):
+    def test_auto(self):
+        np.random.seed(42)
+
+        bins, n = auto_derived_lags(np.random.normal(10, 2, 1000), 'sturges', None)
+
+        # sturges should find 11 classes
+        self.assertTrue(n == 11)
+
+        assert_array_almost_equal(
+            bins,
+            np.array([4.8, 6.1, 7.4, 8.7, 10. , 11.3, 12.5, 13.8, 15.1, 16.4, 17.7]),
+            decimal=1
+        )
+
+    def test_skewed(self):
+        np.random.seed(1312)
+
+        bins, n = auto_derived_lags(np.random.gamma(10, 20, 500), 'doane', 100)
+
+        # doane should condense to 6 here
+        self.assertTrue(n == 6)
+
+        assert_array_almost_equal(
+            bins,
+            np.array([ 75.6, 80.4, 85.3, 90.2, 95.1, 100.]),
+            decimal=1
+        )
 
 if __name__ == '__main__':
     unittest.main()

--- a/skgstat/tests/test_directionalvariogram.py
+++ b/skgstat/tests/test_directionalvariogram.py
@@ -78,6 +78,19 @@ class TestDirectionalVariogramInstantiation(unittest.TestCase):
                 'model name, or it has to be the search area '
                 'itself'
             )
+    
+    def test_binning_change_nlags(self):
+        DV = DirectionalVariogram(self.c, self.v, n_lags=5)
+
+        self.assertEqual(DV.n_lags, 5)
+
+        # go through the n_lags chaning procedure
+        DV.bin_func = 'scott'
+
+        # with scott, there are 6 classes now
+        self.assertEqual(DV.n_lags, 6)
+
+
 
 
 class Mock:

--- a/skgstat/tests/test_spacetimevariogram.py
+++ b/skgstat/tests/test_spacetimevariogram.py
@@ -153,6 +153,30 @@ class TestSpaceTimeVariogramArgumets(unittest.TestCase):
                 str(e), "Only 'max' supported as string argument."
             )
 
+    def test_autoset_lag_bins(self):
+        V = SpaceTimeVariogram(self.c, self.v, xbins='scott', tbins='fd')
+
+        # test if the bins were set correctly
+        self.assertTrue(V.x_lags == 20)
+        self.assertTrue(V.t_lags == 2)
+
+        assert_array_almost_equal(
+            V.xbins,
+            np.array([21.5, 34.8, 48., 61.3, 74.5, 87.8, 101.1, 114.3, 127.6,
+                140.8, 154.1, 167.4, 180.6, 193.9, 207.2, 220.4, 233.7, 246.9,
+                260.2, 273.5]),
+                decimal=1
+        )
+
+    def test_change_lag_method(self):
+        V = V = SpaceTimeVariogram(self.c, self.v, x_lags=4, t_lags='max')
+
+        self.assertTrue(V.x_lags == V.t_lags == 4)
+
+        V.set_bin_func('sqrt', 'space')
+
+        self.assertTrue(V.x_lags == 43)
+
 
 class TestSpaceTimeVariogramPlots(unittest.TestCase):
     def setUp(self):

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -53,13 +53,13 @@ class TestVariogramInstatiation(unittest.TestCase):
 
         for b, e in zip(bins, V.bins):
             self.assertAlmostEqual(b, e, places=2)
-    
+
     def test_unknown_binning_func(self):
         with self.assertRaises(ValueError) as e:
             Variogram(self.c, self.v, bin_func='notafunc')
 
         self.assertEqual(
-            'notafunc binning method is not known',
+            "'notafunc' is not a valid estimator for `bins`",
             str(e.exception)
         )
 

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -117,6 +117,29 @@ class TestVariogramArguments(unittest.TestCase):
         V.bin_func = 'even'
         assert_array_almost_equal(even, V.bins, decimal=2)
 
+    def test_binning_method_scott(self):
+        V = Variogram(self.c, self.v, bin_func='scott')
+
+        # scott should yield 11 bins here
+        self.assertTrue(V.n_lags == 11)
+
+        assert_array_almost_equal(
+            V.bins,
+            np.array([4.9, 8.6, 12.4, 16.1, 19.9, 23.6, 27.3, 31.1, 34.8, 38.6, 42.3]),
+            decimal=1
+        )
+
+    def test_binning_change_nlags(self):
+        V = Variogram(self.c, self.v, n_lags=5)
+
+        # 5 lags are awaited
+        self.assertTrue(V.n_lags == 5)
+
+        # switch to fd rule
+        V.bin_func = 'fd'
+
+        self.assertTrue(V.n_lags == 13)
+
     def test_set_bins_directly(self):
         V = Variogram(self.c, self.v, n_lags=5)
 

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -154,6 +154,11 @@ class TestVariogramArguments(unittest.TestCase):
         self.assertIsNone(V.cov)
         self.assertIsNone(V.cof)
 
+    def test_binning_non_string_arg(self):
+        V = Variogram(self.c, self.v, n_lags=8)
+
+        return True
+
     def test_estimator_method_setting(self):
         """
         Only test if the estimator functions are correctly set. The


### PR DESCRIPTION
This PR makes all methods for automated bin edges selection available, that are implemented in `numpy.histogram_bin_edges`.

Most important are: 
1. Sturges rule
2. Freedman rule
3. Doane rule

This PR needed to introduce breaking changes on the `skgstat.binning` submodule. These functions now need to return the number of bins as a second argument. If the number of bins was not adjusted, `None` is returned.