### PR TITLE
Add custom bins (callable, iterable) and count property

### DIFF
--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -3,7 +3,7 @@ Variogram class
 """
 import copy
 import warnings
-from typing import Iterable, Callable, Union
+from typing import Iterable, Callable, Union, Tuple
 
 import numpy as np
 from pandas import DataFrame
@@ -525,7 +525,7 @@ class Variogram(object):
     def bin_func(self, bin_func):
         self.set_bin_func(bin_func=bin_func)
 
-    def set_bin_func(self, bin_func: Union[str, Iterable, Callable[[np.ndarray,float,float],np.ndarray]]):
+    def set_bin_func(self, bin_func: Union[str, Iterable, Callable[[np.ndarray,float,float], Tuple[np.ndarray, float]]]):
         r"""Set binning function
 
         Sets a new binning function to be used. The new binning method is set

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -705,7 +705,7 @@ class Variogram(object):
         # if the input is an iterable with bin edges, we need to write self._bins here
         else:
             self._bins = bin_func
-            self._maxlag = None
+            self._maxlag = max(bin_func)
             self._n_lags = sum(1 for e in bin_func)
 
         self.cof, self.cov = None, None

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -312,7 +312,7 @@ class Variogram(object):
         self._bin_func = None
         self._groups = None
         self._bins = None
-        self._count = None
+        self._bin_count = None
         self.set_bin_func(bin_func=bin_func)
 
         # Needed for harmonized models
@@ -696,9 +696,9 @@ class Variogram(object):
         # store the name
         self._bin_func_name = bin_func_name
 
-        # reset groups, bins and count
+        # reset groups, bins and bin count
         self._groups = None
-        self._count = None
+        self._bin_count = None
 
         if isinstance(bin_func, str) or isinstance(bin_func, Callable):
             self._bins = None
@@ -782,7 +782,7 @@ class Variogram(object):
         self._bins = np.asarray(bins)
 
         # clean the groups as they are not valid anymore
-        self._count = None
+        self._bin_count = None
         self._groups = None
         self.cov = None
         self.cof = None
@@ -825,20 +825,20 @@ class Variogram(object):
         # if there are no errors, store the passed value
         self._n_lags_passed_value = n
 
-        # reset the groups and count
+        # reset the groups and bin count
         self._groups = None
-        self._count = None
+        self._bin_count = None
 
         # reset the fitting
         self.cof = None
         self.cov = None
 
     @property
-    def count(self):
+    def bin_count(self):
 
-        if self._count is None:
-            self._count = np.fromiter((g.size for g in self.lag_classes()), dtype=int)
-        return self._count
+        if self._bin_count is None:
+            self._bin_count = np.fromiter((g.size for g in self.lag_classes()), dtype=int)
+        return self._bin_count
 
     @property
     def estimator(self):
@@ -1076,10 +1076,10 @@ class Variogram(object):
         # reset fitting
         self.cof, self.cov = None, None
 
-        # remove bins
+        # remove bins, groups, and bin count
         self._bins = None
         self._groups = None
-        self._count = None
+        self._bin_count = None
 
         # set new maxlag
         if value is None:

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -525,13 +525,14 @@ class Variogram(object):
     def bin_func(self, bin_func):
         self.set_bin_func(bin_func=bin_func)
 
-    def set_bin_func(self, bin_func: Union[str, Iterable, Callable[[np.ndarray],np.ndarray]]):
+    def set_bin_func(self, bin_func: Union[str, Iterable, Callable[[np.ndarray,float,float],np.ndarray]]):
         r"""Set binning function
 
         Sets a new binning function to be used. The new binning method is set
         by either a string identifying the new function to be used, or an
         iterable containing the bin edges, or any function that can compute bins
-        from the distances. The string can be one of: ['even', 'uniform', 'fd',
+        from the distances, number of lags and maximum lag.
+        The string can be one of: ['even', 'uniform', 'fd',
          'sturges', 'scott', 'sqrt', 'doane'].
         If the number of lag classes should be estimated automatically, it is
         recommended to use ' sturges' for small, normal distributed locations
@@ -695,14 +696,17 @@ class Variogram(object):
         # store the name
         self._bin_func_name = bin_func_name
 
-        # reset groups and bins
+        # reset groups, bins and count
         self._groups = None
+        self._count = None
 
         if isinstance(bin_func, str) or isinstance(bin_func, Callable):
             self._bins = None
         # if the input is an iterable with bin edges, we need to write self._bins here
         else:
             self._bins = bin_func
+            self._maxlag = None
+            self._n_lags = sum(1 for e in bin_func)
 
         self.cof, self.cov = None, None
 
@@ -821,8 +825,9 @@ class Variogram(object):
         # if there are no errors, store the passed value
         self._n_lags_passed_value = n
 
-        # reset the groups
+        # reset the groups and count
         self._groups = None
+        self._count = None
 
         # reset the fitting
         self.cof = None
@@ -1074,6 +1079,7 @@ class Variogram(object):
         # remove bins
         self._bins = None
         self._groups = None
+        self._count = None
 
         # set new maxlag
         if value is None:

--- a/skgstat/binning.py
+++ b/skgstat/binning.py
@@ -32,7 +32,7 @@ def even_width_lags(distances, n, maxlag):
 
     """
     # maxlags larger than the maximum separating distance will be ignored
-    if maxlag is None: #or maxlag > np.nanmax(distances):
+    if maxlag is None or maxlag > np.nanmax(distances):
         maxlag = np.nanmax(distances)
 
     return np.linspace(0, maxlag, n + 1)[1:], None

--- a/skgstat/binning.py
+++ b/skgstat/binning.py
@@ -32,7 +32,7 @@ def even_width_lags(distances, n, maxlag):
 
     """
     # maxlags larger than the maximum separating distance will be ignored
-    if maxlag is None or maxlag > np.nanmax(distances):
+    if maxlag is None: #or maxlag > np.nanmax(distances):
         maxlag = np.nanmax(distances)
 
     return np.linspace(0, maxlag, n + 1)[1:], None

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -278,20 +278,20 @@ class TestVariogramArguments(unittest.TestCase):
 
         assert np.array_equal(V.bins, custom_bins)
         assert V.n_lags == len(custom_bins)
-        assert V.maxlag is None
+        assert V.maxlag == max(custom_bins)
 
         # check that custom bins have priority over nlags and maxlag
         V = Variogram(self.c, self.v, bin_func=custom_bins, nlags=1000)
 
         assert np.array_equal(V.bins, custom_bins)
         assert V.n_lags == len(custom_bins)
-        assert V.maxlag is None
+        assert V.maxlag == max(custom_bins)
 
         V = Variogram(self.c, self.v, bin_func=custom_bins, maxlag=1000)
 
         assert np.array_equal(V.bins, custom_bins)
         assert V.n_lags == len(custom_bins)
-        assert V.maxlag is None
+        assert V.maxlag == max(custom_bins)
 
     def test_binning_kmeans_method(self):
         V = Variogram(

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -560,32 +560,31 @@ class TestVariogramArguments(unittest.TestCase):
 
             self.assertTrue('read-only' in str(e.exception))
 
-    def test_get_count(self):
+    def test_get_bin_count(self):
 
         V = Variogram(self.c, self.v)
 
         # check type
-        assert isinstance(V.count, np.ndarray)
+        assert isinstance(V.bin_count, np.ndarray)
 
-        # check against real count
-        assert np.array_equal(V.count, np.array([22, 54, 87, 65, 77, 47, 46, 24, 10,  2]))
+        # check against real bin count
+        assert np.array_equal(V.bin_count, np.array([22, 54, 87, 65, 77, 47, 46, 24, 10,  2]))
 
         # check property gets updated
-        old_count = V.count
+        old_bin_count = V.bin_count
 
         # when setting binning function
         V.bin_func = 'uniform'
-        assert not np.array_equal(V.count, old_count)
+        assert not np.array_equal(V.bin_count, old_bin_count)
 
         # when setting maxlag
-        old_count = V.count
+        old_bin_count = V.bin_count
         V.maxlag = 25
-        assert not np.array_equal(V.count, old_count)
+        assert not np.array_equal(V.bin_count, old_bin_count)
 
         # when setting nlags
-        old_count = V.count
         V.n_lags = 5
-        assert len(V.count) == 5
+        assert len(V.bin_count) == 5
 
 class TestVariogramFittingProcedure(unittest.TestCase):
     def setUp(self):

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -255,8 +255,13 @@ class TestVariogramArguments(unittest.TestCase):
         self.assertIsNone(V.cov)
         self.assertIsNone(V.cof)
 
-    def test_binning_non_string_arg(self):
-        V = Variogram(self.c, self.v, n_lags=8)
+    def test_binning_callable_arg(self):
+
+        def even_func(distances, n, maxlag):
+            return np.linspace(0, np.min(np.nanmax(distances), maxlag), n + 1)[1:]
+
+        V = Variogram(self.c, self.v, n_lags=8, bin_func=even_func)
+        V2 = Variogram(self.c, self.v, n_lags=8, bin_func='even')
 
         return True
 


### PR DESCRIPTION
Discussion that started in #111 

## Customs bins

- the `bin_func` argument has been extended to allow for `Callable` (custom function for binning) or `Iterable` (custom bin edges) as input. Default behaviour is that, when an Iterable is used, the `nlags` and `maxlag` arguments are ignored if provided by the user, and later set according to the Iterable length and maximum.
- added `test_binning_callable_arg` and `test_binning_iterable_arg` to check everything worked properly.

## Count property

- a `count` attribute is now accessible by users with the sample count of pairwise distances per bin, and automatically updated when re-computing bins with a new `bin_func`, `nlags` or `maxlag`.
- added `test_get_count` to check the above behaviour.

## To possibly add?

- check if the Callable indeed takes 3 arguments of the right shape (distances, nlag, maxlag), and returns two of the right type as well (array, float), otherwise raise error specifying the desired Callable format.
- check whether the Iterable/Callable `bin_func` returns bins in ascending lag order, and raise an error otherwise?

## PS: tests

I have 3 tests failing with `unittest` in `test_variogram.py` directly after cloning the `master` branch, not sure why!

See below
```
FAIL: test_dense_maxlag_inf (test_variogram.TestSpatiallyCorrelatedData)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/tests/test_variogram.py", line 48, in test_dense_maxlag_inf
    self.assertAlmostEqual(x, y, places=3)
AssertionError: 26.058669854641856 != 49999.99999500066 within 3 places (49973.94132514602 difference)

======================================================================
FAIL: test_sparse_maxlag_30 (test_variogram.TestSpatiallyCorrelatedData)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/tests/test_variogram.py", line 60, in test_sparse_maxlag_30
    self.assertAlmostEqual(x, y, places=3)
AssertionError: 17.129667030800196 != 17.128 within 3 places (0.0016670308001955902 difference)

======================================================================
FAIL: test_binning_iterable_arg (test_variogram.TestVariogramArguments)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/tests/test_variogram.py", line 288, in test_binning_iterable_arg
    assert V.maxlag is max(custom_bins)
AssertionError
```