### PR TITLE
Fix for RasterMetricSpace

### DIFF
--- a/skgstat/MetricSpace.py
+++ b/skgstat/MetricSpace.py
@@ -409,7 +409,10 @@ def _get_disk_sample(
     # sample for low distances
     indices2 = rnd_func.choice(count, size=min(count, sample_count), replace=False)
 
-    return indices1[indices2].squeeze()
+    if count != 1:
+        return indices1[indices2].squeeze()
+    else:
+        return indices1[indices2][0]
 
 
 def _get_successive_ring_samples(
@@ -443,8 +446,11 @@ def _get_successive_ring_samples(
         # sample for low distances
         indices2 = rnd_func.choice(count, size=min(count, sample_count), replace=False)
         sub_idx = indices1[indices2]
-        if len(sub_idx) > 1:
+
+        if count > 1:
             list_idx.append(sub_idx.squeeze())
+        elif count == 1:
+            list_idx.append(sub_idx[0])
 
     return np.concatenate(list_idx)
 
@@ -716,7 +722,7 @@ class RasterEquidistantMetricSpace(MetricSpace):
         # Derive distances
         if self._dists is None:
 
-            idx_center = self.rnd.choice(len(self.coords), size=self.runs, replace=False)
+            idx_center = self.rnd.choice(len(self.coords), size=min(self.runs, len(self.coords)), replace=False)
 
             # Each run has a different center
             centers = self.coords[idx_center]

--- a/skgstat/MetricSpace.py
+++ b/skgstat/MetricSpace.py
@@ -407,7 +407,7 @@ def _get_disk_sample(
     # Second index: randomly select half of the valid pixels, 
     # so that the other half can be used by the equidist
     # sample for low distances
-    indices2 = rnd_func.choice(count, size=sample_count, replace=False)
+    indices2 = rnd_func.choice(count, size=min(count, sample_count), replace=False)
 
     return indices1[indices2].squeeze()
 

--- a/skgstat/tests/test_metric_space.py
+++ b/skgstat/tests/test_metric_space.py
@@ -113,3 +113,10 @@ def test_raster_metric():
     # Check the variogram is always the same with the random state given
     assert V.experimental[0] == pytest.approx(0.89,0.01)
 
+    # Check that the routines are robust to very few data points in the grid (e.g., from nodata values)
+    coords_sub = coords[0::1000]
+    vals_sub = vals[0::1000]
+    rems_sub = skg.RasterEquidistantMetricSpace(coords_sub, shape=shape, extent=(x[0],x[-1],y[0],y[-1]), samples=100, runs=10,
+                                            rnd=42)
+    V = skg.Variogram(rems_sub, vals_sub)
+

--- a/skgstat/tests/test_metric_space.py
+++ b/skgstat/tests/test_metric_space.py
@@ -120,3 +120,9 @@ def test_raster_metric():
                                             rnd=42)
     V = skg.Variogram(rems_sub, vals_sub)
 
+    # Check with a single isolated point possibly being used as center
+    coords_sub = np.concatenate(([coords[0]], coords[-10:]))
+    vals_sub = np.concatenate(([vals[0]], vals[-10:]))
+    rems_sub = skg.RasterEquidistantMetricSpace(coords_sub, shape=shape, extent=(x[0],x[-1],y[0],y[-1]), samples=100, runs=11,
+                                            rnd=42)
+    V = skg.Variogram(rems_sub, vals_sub)


### PR DESCRIPTION
### Issue
In some cases, having a low number of valid coordinates of the grid results in an error:
```python
# Generate a gridded dataset
shape = (100, 100)
np.random.seed(42)
vals = np.random.normal(0, 1, size=shape)

# Coordinates
x = np.arange(0, shape[0])
y = np.arange(0, shape[1])
xx, yy = np.meshgrid(x, y)

# Flatten everything because we don't care about the 2D at this point
coords = np.dstack((xx.flatten(), yy.flatten())).squeeze()
vals = vals.flatten()

# Check that the routines are robust to very few data points in the grid (e.g., from nodata values)
coords_sub = coords[0::1000]
vals_sub = vals[0::1000]
rems_sub = skg.RasterEquidistantMetricSpace(coords_sub, shape=shape, extent=(x[0],x[-1],y[0],y[-1]), samples=100, runs=10,
                                        rnd=42)
V = skg.Variogram(rems_sub, vals_sub)
```
which yielded:
```
Traceback (most recent call last):
  File "<input>", line 6, in <module>
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/Variogram.py", line 322, in __init__
    self.preprocessing(force=True)
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/Variogram.py", line 1364, in preprocessing
    self._calc_diff(force=force)
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/Variogram.py", line 1656, in _calc_diff
    if isinstance(self.distance_matrix, sparse.spmatrix):
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/Variogram.py", line 1051, in distance_matrix
    return self._X.dists
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/MetricSpace.py", line 732, in dists
    dists, cidx, eqidx = _get_idx_dists(self.coords, center=center, center_radius=self._center_radius,
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/MetricSpace.py", line 473, in _get_idx_dists
    cidx = _get_disk_sample(
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/MetricSpace.py", line 410, in _get_disk_sample
    indices2 = rnd_func.choice(count, size=sample_count, replace=False)
  File "mtrand.pyx", line 965, in numpy.random.mtrand.RandomState.choice
ValueError: Cannot take a larger sample than population when 'replace=False'
```

### Fix

This is fixed by replacing
```python
    indices2 = rnd_func.choice(count, size=sample_count, replace=False)
```
by
```python
    indices2 = rnd_func.choice(count, size=min(count, sample_count), replace=False)
```
in `_get_disk_sample`, as was already done in `_get_successive_ring_samples`.

I also added the above test in `test_metric_space` to ensure this issue doesn't occur again.


## EDIT:

### Found a small second issue
When a single coordinates is drawn for the center sample (no data all around it on the grid), it results into an error.
```python
# Check with a single isolated point possibly being used as center
coords_sub = np.concatenate(([coords[0]], coords[-10:]))
vals_sub = np.concatenate(([vals[0]], vals[-10:]))
rems_sub = skg.RasterEquidistantMetricSpace(coords_sub, shape=shape, extent=(x[0],x[-1],y[0],y[-1]), samples=100, runs=11,
                                        rnd=42)
V = skg.Variogram(rems_sub, vals_sub)
```
```
Traceback (most recent call last):
  File "<input>", line 6, in <module>
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/Variogram.py", line 322, in __init__
    self.preprocessing(force=True)
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/Variogram.py", line 1364, in preprocessing
    self._calc_diff(force=force)
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/Variogram.py", line 1656, in _calc_diff
    if isinstance(self.distance_matrix, sparse.spmatrix):
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/Variogram.py", line 1051, in distance_matrix
    return self._X.dists
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/MetricSpace.py", line 738, in dists
    dists, cidx, eqidx = _get_idx_dists(self.coords, center=center, center_radius=self._center_radius,
  File "/home/atom/code/devel/libs/scikit-gstat/skgstat/MetricSpace.py", line 494, in _get_idx_dists
    ctree = cKDTree(coords[cidx, :])
  File "ckdtree.pyx", line 565, in scipy.spatial.ckdtree.cKDTree.__init__
ValueError: data must be 2 dimensions
```
### Fix
This is because `squeeze` modifies the expected output shape when the subsample coordinate happens to be a single point.
Added an if loop for this specific case in `_get_disk_sample` and `_get_successive_ring_samples`:
```python
if count != 1:
    return indices1[indices2].squeeze()
else:
    return indices1[indices2][0]
```
And added the example above in `test_metric_space`.