### PR TITLE
raise Error instead of warning

### DIFF
--- a/skgstat/binning.py
+++ b/skgstat/binning.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 from sklearn.cluster import KMeans, AgglomerativeClustering
 from sklearn.exceptions import ConvergenceWarning
@@ -165,11 +166,16 @@ def kmeans(distances, n, maxlag, binning_random_state=42, **kwargs):
     # filter for distances < maxlag
     d = distances[np.where(distances <= maxlag)]
 
-    # cluster the filtered distances
-    try:
-        km = KMeans(n_clusters=n, random_state=binning_random_state).fit(d.reshape(-1, 1))
-    except ConvergenceWarning:
-        raise ValueError("KMeans failed to converge. Maybe you need to use a different n_lags.")
+    # filter the sklearn convervence warning, because working with 
+    # undefined state in binning does not make any sense
+    with warnings.catch_warnings():
+        warnings.filterwarnings('error')
+
+        # cluster the filtered distances
+        try:
+            km = KMeans(n_clusters=n, random_state=binning_random_state).fit(d.reshape(-1, 1))
+        except ConvergenceWarning:
+            raise ValueError("KMeans failed to converge. Maybe you need to use a different n_lags.")
 
     # get the centers
     _centers = np.sort(km.cluster_centers_.flatten())

--- a/skgstat/binning.py
+++ b/skgstat/binning.py
@@ -1,5 +1,6 @@
 import numpy as np
 from sklearn.cluster import KMeans, AgglomerativeClustering
+from sklearn.exceptions import ConvergenceWarning
 from scipy.optimize import minimize, OptimizeWarning
 
 from skgstat.util import shannon_entropy
@@ -165,7 +166,10 @@ def kmeans(distances, n, maxlag, binning_random_state=42, **kwargs):
     d = distances[np.where(distances <= maxlag)]
 
     # cluster the filtered distances
-    km = KMeans(n_clusters=n, random_state=binning_random_state).fit(d.reshape(-1, 1))
+    try:
+        km = KMeans(n_clusters=n, random_state=binning_random_state).fit(d.reshape(-1, 1))
+    except ConvergenceWarning:
+        raise ValueError("KMeans failed to converge. Maybe you need to use a different n_lags.")
 
     # get the centers
     _centers = np.sort(km.cluster_centers_.flatten())

--- a/skgstat/tests/test_binning.py
+++ b/skgstat/tests/test_binning.py
@@ -123,6 +123,10 @@ class TestClusteringBins(unittest.TestCase):
             decimal=1
         )
 
+    def test_kmeans_convergence(self):
+        with self.assertRaises(ValueError) as err:
+            kmeans(np.array([1,2,3,4]), 5, None)
+
     def test_ward(self):
         np.random.seed(1312)
         bins, _ = ward(np.random.gamma(10, 40, 500), 6, None)

--- a/skgstat/tests/test_binning.py
+++ b/skgstat/tests/test_binning.py
@@ -125,7 +125,9 @@ class TestClusteringBins(unittest.TestCase):
 
     def test_kmeans_convergence(self):
         with self.assertRaises(ValueError) as err:
-            kmeans(np.array([1,2,3,4]), 5, None)
+            kmeans(np.array([1, 1, 1, 1, 1]), 3, None)
+        
+        self.assertTrue('KMeans failed to converge' in str(err.exception))
 
     def test_ward(self):
         np.random.seed(1312)


### PR DESCRIPTION
If KMeans can't find the requested number of lag classes, raise a `ValueError` instead of `sklearn.exceptions.ConvergenceWarning`