### PR TITLE
Use `warnings` instead of `raise Warning`

### DIFF
--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -333,7 +333,9 @@ class Variogram(object):
         self.use_nugget = use_nugget
 
         # set the fitting method and sigma array
-        self._fit_method = fit_method
+        self._fit_method = None
+        if fit_method is not None:
+            self.fit_method = fit_method
         self._fit_sigma = None
         self.fit_sigma = fit_sigma
 
@@ -457,6 +459,9 @@ class Variogram(object):
         differences are recalculated.
         Raises :py:class:`ValueError`s on shape mismatches and a Warning
 
+        .. versionchanged::
+            Now a warnings.warn message is thrown if all input data is the same
+
         Parameters
         ----------
         values : numpy.ndarray
@@ -489,7 +494,10 @@ class Variogram(object):
 
         # check if all input values are the same
         if len(set(_y)) < 2:
-            raise Warning('All input values are the same.')
+            self.__single_input = True
+            warnings.warn('All input values are the same.')
+        else:
+            self.__single_input = False
 
         # reset fitting parameter
         self.cof, self.cov = None, None
@@ -1160,6 +1168,10 @@ class Variogram(object):
         # value is fine -check for manual does not drop the coefficients
         elif value == 'manual':
             self._fit_method = 'manual'
+
+        # Trust region reflective does not work wi
+        elif value == 'trf' and self.__single_input:
+            raise AttributeError("'trf' is bounded and therefore not supported when all values are the same.")
 
         # otherwise - refit
         else:

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -149,13 +149,28 @@ class TestVariogramInstatiation(unittest.TestCase):
         )
 
     def test_value_warning(self):
-        with self.assertRaises(Warning) as w:
-            Variogram(self.c, [42] * 30)
-        
+        with self.assertWarns(Warning) as w:
+            Variogram(self.c, [42] * 30, fit_method='lm')
+
         self.assertEqual(
             'All input values are the same.',
-            str(w.exception)
+            str(w.warning)
         )
+
+    def test_value_error_on_set_trf(self):
+        """Test the Attribute error when switching to TRF on single value input"""
+        with self.assertRaises(AttributeError) as e:
+            v = Variogram(self.c, [42] * 30, fit_method='lm')
+            v.fit_method = 'trf'
+
+        self.assertTrue("'trf' is bounded and therefore" in str(e.exception))
+    
+    def test_value_error_trf(self):
+        """Test the Attribute error on TRF instantiation on single value input"""
+        with self.assertRaises(AttributeError) as e:
+            v = Variogram(self.c, [42] * 30, fit_method='trf')
+
+        self.assertTrue("'trf' is bounded and therefore" in str(e.exception))
 
 
 class TestVariogramArguments(unittest.TestCase):


### PR DESCRIPTION
When single values arrays are passed to a `Variogram` instance, a warning should be given to the user. Up to now, this was implemented as `raise Warning`, which technically raised an Exception that could not be filtered.
This is replaced by `warnings.warn` now.