### PR TITLE
Pairwise_diffs property added

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
 Version 1.1-rc
 ==============
 
+Version 1.0.4
+-------------
+- [Variogram] :func:`Variogram.pairwise_diffs <skgstat.Variogram.pairwise_diffs>` wraps around old ``_diff``
+  and should be used instead of directly accessing ``_diff``
+- [Variogram] :func:`Variogram.model_residuals <skgstat.Variogram.model_residuals>` will replace 
+  ``Variogram.residuals`` which has been deprecated
+
 Version 1.0.1
 -------------
 - [Variogram] documentation added to :func:`use_nugget <skgstat.Variogram.use_nugget>`

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -375,7 +375,7 @@ class Variogram(object):
     def metric_space(self):
         r"""
         .. versionadded:: 0.5.6
-        
+
         :class:`MetricSpace <skgstat.MetricSpace>` representation of the
         input coordinates. A :class:`MetricSpace <skgstat.MetricSpace>`
         can be used to pass pre-calculated coordinates to other
@@ -509,6 +509,19 @@ class Variogram(object):
         # recalculate the pairwise differences
         if calc_diff:
             self._calc_diff(force=True)
+
+    @property
+    def residuals(self):
+        """
+        .. versionadded:: 1.0.4
+
+        Pairwise residual differences of the input data.
+        The property should be used over the Variogram._diff attribute,
+        as this will contain multiple targets with future releases to
+        implement cross-variograms.
+
+        """
+        return self._diff
 
     @property
     def bin_func(self):

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -1379,9 +1379,12 @@ class Variogram(object):
         iterable
 
         """
+        # get the diffs
+        diffs = self.pairwise_diffs
+        
         # yield all groups
         for i in range(len(self.bins)):
-            yield self._diff[np.where(self.lag_groups() == i)]
+            yield diffs[np.where(self.lag_groups() == i)]
 
     def preprocessing(self, force=False):
         """Preprocessing function

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -511,7 +511,7 @@ class Variogram(object):
             self._calc_diff(force=True)
 
     @property
-    def residuals(self):
+    def pairwise_diffs(self):
         """
         .. versionadded:: 1.0.4
 

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -1984,9 +1984,30 @@ class Variogram(object):
         experimental variogram and the theoretical model values at
         corresponding lag values
 
+        .. deprecated:: 1.0.4
+            residuals can be ambigious, thus the property is renamed to model_residuals
+
         Returns
         -------
         numpy.ndarray
+
+        """
+        warnings.warn(
+            "residuals is deprecated and will be removed. Please use Variogram.model_residuals",
+            DeprecationWarning
+        )
+        return self.model_residuals
+
+    @property
+    def model_residuals(self) -> np.ndarray:
+        """
+        Calculate the model residuals defined as the differences between the
+        experimental variogram and the theoretical model values at
+        corresponding lag values.
+
+        Returns
+        -------
+        residuals : numpy.ndarray
 
         """
         # get the deviations

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -447,7 +447,7 @@ class Variogram(object):
         Variogram._diff
 
         """
-        return squareform(self._diff)
+        return squareform(self.pairwise_diffs)
 
     def set_values(self, values, calc_diff=True):
         """Set new values
@@ -521,6 +521,9 @@ class Variogram(object):
         implement cross-variograms.
 
         """
+        if self._diff is None:
+            self.preprocessing()
+
         return self._diff
 
     @property

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -5,7 +5,7 @@ import pickle
 import numpy as np
 import pandas as pd
 from numpy.testing import assert_array_almost_equal
-import matplotlib.pyplot as plt
+from scipy.spatial.distance import pdist
 
 try:
     import plotly.graph_objects as go
@@ -171,6 +171,20 @@ class TestVariogramInstatiation(unittest.TestCase):
             v = Variogram(self.c, [42] * 30, fit_method='trf')
 
         self.assertTrue("'trf' is bounded and therefore" in str(e.exception))
+
+    def test_residuals_diffs(self):
+        """
+        Test that the cross-variogram changes do not mess with the standard
+        implementation of Variogram.
+
+        """
+        # build the variogram
+        V = Variogram(self.c, self.v)
+
+        # build the actual triangular distance matrix array
+        diff = pdist(np.column_stack((self.v, np.zeros(len(self.v)))), metric='euclidean')
+
+        assert_array_almost_equal(V.pairwise_diffs, diff, decimal=2)
 
 
 class TestVariogramArguments(unittest.TestCase):

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -172,7 +172,7 @@ class TestVariogramInstatiation(unittest.TestCase):
 
         self.assertTrue("'trf' is bounded and therefore" in str(e.exception))
 
-    def test_residuals_diffs(self):
+    def test_pairwise_diffs(self):
         """
         Test that the cross-variogram changes do not mess with the standard
         implementation of Variogram.
@@ -184,6 +184,22 @@ class TestVariogramInstatiation(unittest.TestCase):
         # build the actual triangular distance matrix array
         diff = pdist(np.column_stack((self.v, np.zeros(len(self.v)))), metric='euclidean')
 
+        assert_array_almost_equal(V.pairwise_diffs, diff, decimal=2)
+    
+    def test_pairwise_diffs_preprocessing(self):
+        """
+        Remove the diffs and then request the diffs again to check preprocessing
+        trigger on missing pairwise residual diffs.
+        """
+        V = Variogram(self.c, self.v)
+
+        # build the diffs
+        diff = pdist(np.column_stack((self.v, np.zeros(len(self.v)))), metric='euclidean')
+
+        # remove the diffs
+        V._diff = None
+
+        # check preprocessing
         assert_array_almost_equal(V.pairwise_diffs, diff, decimal=2)
 
 

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -1048,7 +1048,7 @@ class TestVariogramQualityMeasures(unittest.TestCase):
             Variogram(self.c, self.v).residuals
 
         self.assertTrue('residuals is deprecated and will be removed' in str(w.warning))
-            
+  
 
 class TestVariogramMethods(unittest.TestCase):
     def setUp(self):

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -1042,6 +1042,13 @@ class TestVariogramQualityMeasures(unittest.TestCase):
         with self.assertRaises(AssertionError):
             assert_array_almost_equal(exp, exp2, decimal=2)
 
+    def test_residuals_deprecation(self):
+        """Variogram.residuals is deprecated in favor of model_residuals"""
+        with self.assertWarns(DeprecationWarning) as w:
+            Variogram(self.c, self.v).residuals
+
+        self.assertTrue('residuals is deprecated and will be removed' in str(w.warning))
+            
 
 class TestVariogramMethods(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
This PR introduces a new property called `pairwise_diffs`, which right now only wraps `Variogram._diff` to make it accessible through a stable interface. This will be important if Variogram is extended to handle cross-variograms.

Additionally, the `Variogram.residuals` was deprecated in favor of `Variogram.model_residuals` to make the interface clearer. The Vairogram, however, has not been moved to use this new property yet.
That will happen in an extra warning-handling PR (cause there are many...)