### PR TITLE
Cross variogram

### DIFF
--- a/skgstat/DirectionalVariogram.py
+++ b/skgstat/DirectionalVariogram.py
@@ -94,11 +94,11 @@ class DirectionalVariogram(Variogram):
         bin_func : str
             .. versionchanged:: 0.3.8
                 added 'fd', 'sturges', 'scott', 'sqrt', 'doane'
-            
+
             String identifying the binning function used to find lag class
             edges. All methods calculate bin edges on the interval [0, maxlag[.
             Possible values are:
-            
+
                 * `'even'` (default) finds `n_lags` same width bins
                 * `'uniform'` forms `n_lags` bins of same data count
                 * `'fd'` applies Freedman-Diaconis estimator to find `n_lags`
@@ -245,6 +245,11 @@ class DirectionalVariogram(Variogram):
 
         # set verbosity
         self.verbose = verbose
+
+        # declare a flag to mark if this is a covariogram
+        # this is set to None, as set_values will figure out
+        self._is_cross = None
+        self._co_variable = None
 
         # set values
         self._values = None
@@ -396,7 +401,6 @@ class DirectionalVariogram(Variogram):
         # store the angle or negative angle, depending on the
         # amount of the x coordinate
         self._angles = np.where(ydiff >= 0, pos_angles, -pos_angles)
-
 
     @property
     def azimuth(self):

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -289,7 +289,7 @@ class Variogram(object):
         # set verbosity
         self.verbose = verbose
 
-        # declate a flag to mark if this is a covariogram
+        # declare a flag to mark if this is a covariogram
         # this is set to None, as set_values will figure out.
         self._is_cross = None
         self._co_variable = None

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -517,6 +517,8 @@ class Variogram(object):
 
                 # by definition, the first axis is the observation
                 _y = _y[:, 0].flatten()
+        else:
+            self._is_cross = False
 
         # check if all input values are the same
         if len(set(_y)) < 2:

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -289,6 +289,11 @@ class Variogram(object):
         # set verbosity
         self.verbose = verbose
 
+        # declate a flag to mark if this is a covariogram
+        # this is set to None, as set_values will figure out.
+        self._is_cross = None
+        self._co_variable = None
+
         # set values
         self._values = None
         # calc_diff = False here, because it will be calculated by fit() later
@@ -488,9 +493,14 @@ class Variogram(object):
 
         # use an array
         _y = np.asarray(values)
-        if not _y.ndim == 1:  # pragma: no cover
-            raise ValueError('The values shall be a 1-D array.' +
-                             'Multi-dimensional values not supported yet.')
+
+        # check if this is should be a cross-variogram
+        # TODO: run tests for this
+        if _y.ndim > 2:  # pragma: no cover
+            raise ValueError("Use the utility function to create a grid of cross-variograms")
+        elif _y.ndim == 2:
+            # TODO: this is what we are after
+            raise NotImplementedError("Cross-Variogram not yet implemented")
 
         # check if all input values are the same
         if len(set(_y)) < 2:

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -1334,6 +1334,11 @@ class Variogram(object):
         self.cof = None
         self.cov = None
 
+    @property
+    def is_cross_variogram(self) -> bool:
+        """Read-only flag indicating if the current instance is a cross-variogram"""
+        return self._is_cross
+
     def update_kwargs(self, **kwargs):
         """
         .. versionadded:: 0.3.7

--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -496,11 +496,27 @@ class Variogram(object):
 
         # check if this is should be a cross-variogram
         # TODO: run tests for this
-        if _y.ndim > 2:  # pragma: no cover
-            raise ValueError("Use the utility function to create a grid of cross-variograms")
+        if _y.ndim > 2:
+            raise ValueError(
+                "values has to be 1d (classic variogram) or 2d dimensional (cross-variogram)"
+            )  
         elif _y.ndim == 2:
-            # TODO: this is what we are after
-            raise NotImplementedError("Cross-Variogram not yet implemented")
+            if _y.shape[1] > 2:
+                raise ValueError(
+                    "Use the utility function to create a grid of cross-variograms"
+                )
+            elif _y.shape[1] == 2:
+                # set the co-variable
+                self._co_variable = _y[:, 1].flatten()
+
+                # generate a warning if the cross variogram flag was set to False
+                if self._is_cross is not None and not self._is_cross:
+                    warnings.warn("You passed two variables as observation and " +
+                        "effectively turned this instance into a cross-variogram.")
+                self._is_cross = True
+
+                # by definition, the first axis is the observation
+                _y = _y[:, 0].flatten()
 
         # check if all input values are the same
         if len(set(_y)) < 2:
@@ -514,7 +530,7 @@ class Variogram(object):
         self._diff = None
 
         # set new values
-        self._values = np.asarray(values)
+        self._values = np.asarray(_y)
 
         # recalculate the pairwise differences
         if calc_diff:

--- a/skgstat/plotting/variogram_dd_plot.py
+++ b/skgstat/plotting/variogram_dd_plot.py
@@ -1,28 +1,25 @@
 import numpy as np
 import matplotlib.pyplot as plt
+from scipy.spatial.distance import squareform
 
 try:
-    import plotly.graph_objects as go 
+    import plotly.graph_objects as go
 except ImportError:
     pass
 
 
 def __calculate_plot_data(variogram):
-   # get all distances
-    _dist = variogram.distance
+    # get all distances and residual diffs
+    dist = variogram.distance
+    diff = variogram.pairwise_diffs
 
-    # get all differences
-    if variogram._diff is None:
-        variogram._calc_diff()
-    _diff = variogram._diff
-
-    return _diff, _dist
+    return diff, dist
 
 
 def matplotlib_dd_plot(variogram, ax=None, plot_bins=True, show=True):
-    # get the plotting data 
+    # get the plotting data
     _diff, _dist = __calculate_plot_data(variogram)
-   
+
     # create the plot
     if ax is None:
         fig, ax = plt.subplots(1, 1, figsize=(8, 6))
@@ -62,7 +59,7 @@ def plotly_dd_plot(variogram, fig=None, plot_bins=True, show=True):
     # plot
     fig.add_trace(
         go.Scattergl(
-            x=_dist, y=_diff, 
+            x=_dist, y=_diff,
             mode='markers', marker=dict(color='blue', opacity=0.5)
         )
     )

--- a/skgstat/tests/test_directionalvariogram.py
+++ b/skgstat/tests/test_directionalvariogram.py
@@ -91,7 +91,6 @@ class TestDirectionalVariogramInstantiation(unittest.TestCase):
 
 
 
-
 class Mock:
     def __init__(self, c=None, v=None):
         self._X = c

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -14,7 +14,7 @@ except ImportError:
     print('No plotly installed. Skip plot tests')
     PLOTLY_FOUND = False
 
-from skgstat import Variogram
+from skgstat import Variogram, DirectionalVariogram
 from skgstat import OrdinaryKriging
 from skgstat import estimators
 from skgstat import plotting
@@ -1325,6 +1325,26 @@ class TestCrossVariogram(unittest.TestCase):
         vario = Variogram(self.c, self.v, maxlag='median')
 
         self.assertTrue(vario.pairwise_diffs.ndim == 1)
+
+    def test_covariable(self):
+        """check that the covariable was correctly instantiated"""
+        vario = Variogram(self.c, self.v, maxlag='median')
+
+        self.assertTrue(vario.is_cross_variogram)
+        assert_array_almost_equal(self.v[:,1], vario._co_variable)
+
+    def test_directional_instantiation(self):
+        """Check that the directional variogram is also instantiated."""
+        vario = DirectionalVariogram(self.c, self.v, maxlag='median')
+
+        self.assertTrue(vario.pairwise_diffs.ndim == 1)
+
+    def test_directional_covariable(self):
+        """Check that the directional variogram instantiated the covariable correctly"""
+        vario = DirectionalVariogram(self.c, self.v, maxlag='median')
+
+        self.assertTrue(vario.is_cross_variogram)
+        assert_array_almost_equal(self.v[:,1], vario._co_variable)
 
 
 if __name__ == '__main__':  # pragma: no cover

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -1048,7 +1048,7 @@ class TestVariogramQualityMeasures(unittest.TestCase):
             Variogram(self.c, self.v).residuals
 
         self.assertTrue('residuals is deprecated and will be removed' in str(w.warning))
-  
+
 
 class TestVariogramMethods(unittest.TestCase):
     def setUp(self):
@@ -1266,7 +1266,7 @@ class TestSampling(unittest.TestCase):
             self.assertAlmostEqual(Vf["effective_range"], Vs["effective_range"], delta = Vf["effective_range"] / 5)
             self.assertAlmostEqual(Vf["sill"], Vs["sill"], delta = Vf["sill"] / 5)
 
-       
+
 class TestVariogramPickling(unittest.TestCase):
     def setUp(self):
         # set up default values, whenever c and v are not important
@@ -1284,6 +1284,35 @@ class TestVariogramPickling(unittest.TestCase):
         pickle.loads(pickle.dumps(self.V))
         return True
 
+
+class TestCrossVariogram(unittest.TestCase):
+    def setUp(self):
+        # set up default values, whenever c and v are not important
+        np.random.seed(42)
+        self.c = np.random.gamma(10, 4, (30, 2))
+        np.random.seed(42)
+        self.v = np.random.normal(10, 4, (30, 2))
+
+    def test_cross_variable_dim_error(self):
+        """Generate values of too high dimensionality"""
+        # generate 3D values
+        np.random.seed(42)
+        v = np.random.normal(10, 4, (30, 3, 3))
+
+        with self.assertRaises(ValueError) as e:
+            Variogram(self.c, v)
+
+        self.assertTrue('values has to be 1d (classic variogram)' in str(e.exception))
+
+    def test_too_many_cross_variables(self):
+        """Generate too many co-variables"""
+        np.random.seed(42)
+        v = np.random.normal(10, 3, (30,3))
+
+        with self.assertRaises(ValueError) as e:
+            Variogram(self.c, v)
+
+        self.assertTrue('create a grid of cross-variograms' in str(e.exception))
 
 if __name__ == '__main__':  # pragma: no cover
     import os

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -1289,15 +1289,15 @@ class TestCrossVariogram(unittest.TestCase):
     def setUp(self):
         # set up default values, whenever c and v are not important
         np.random.seed(42)
-        self.c = np.random.gamma(10, 4, (30, 2))
+        self.c = np.random.gamma(10, 4, (100, 2))
         np.random.seed(42)
-        self.v = np.random.normal(10, 4, (30, 2))
+        self.v = np.random.multivariate_normal([10.5, 5.6], [[1.5, 3.2], [3.2, 1.5]], size=100)
 
     def test_cross_variable_dim_error(self):
         """Generate values of too high dimensionality"""
         # generate 3D values
         np.random.seed(42)
-        v = np.random.normal(10, 4, (30, 3, 3))
+        v = np.random.normal(10, 4, (100, 3, 3))
 
         with self.assertRaises(ValueError) as e:
             Variogram(self.c, v)
@@ -1307,14 +1307,26 @@ class TestCrossVariogram(unittest.TestCase):
     def test_too_many_cross_variables(self):
         """Generate too many co-variables"""
         np.random.seed(42)
-        v = np.random.normal(10, 3, (30,3))
+        v = np.random.normal(10, 3, (100, 3))
 
         with self.assertRaises(ValueError) as e:
             Variogram(self.c, v)
 
         self.assertTrue('create a grid of cross-variograms' in str(e.exception))
+    
+    def test_cross_instantiation(self):
+        """Create a cross-variogram without error"""
+        vario = Variogram(self.c, self.v, maxlag='median')
+
+        self.assertTrue(vario.is_cross_variogram)
+
+    def test_cross_shapes(self):
+        """diffs needs to be a 2d matrix now"""
+        vario = Variogram(self.c, self.v, maxlag='median')
+
+        self.assertTrue(vario.pairwise_diffs.ndim == 2)
+
 
 if __name__ == '__main__':  # pragma: no cover
-    import os
     os.environ['SKG_SUPRESS'] = 'TRUE'
     unittest.main()

--- a/skgstat/tests/test_variogram.py
+++ b/skgstat/tests/test_variogram.py
@@ -73,7 +73,7 @@ class TestVariogramInstatiation(unittest.TestCase):
 
         for x, y in zip(V.parameters, [7.122, 13.966, 0]):
             self.assertAlmostEqual(x, y, places=3)
-            
+
     def test_sparse_standard_settings(self):
         V = Variogram(self.c, self.v, maxlag=10000)
 
@@ -127,7 +127,7 @@ class TestVariogramInstatiation(unittest.TestCase):
         with self.assertRaises(AttributeError) as e:
             V = Variogram(self.c, self.v)
             V.set_bin_func(42)
-        
+
         self.assertTrue('of type string' in str(e.exception))
 
     def test_unknown_model(self):
@@ -1313,7 +1313,7 @@ class TestCrossVariogram(unittest.TestCase):
             Variogram(self.c, v)
 
         self.assertTrue('create a grid of cross-variograms' in str(e.exception))
-    
+
     def test_cross_instantiation(self):
         """Create a cross-variogram without error"""
         vario = Variogram(self.c, self.v, maxlag='median')
@@ -1321,10 +1321,10 @@ class TestCrossVariogram(unittest.TestCase):
         self.assertTrue(vario.is_cross_variogram)
 
     def test_cross_shapes(self):
-        """diffs needs to be a 2d matrix now"""
+        """Check that the cross-variogram does not change the diff shape"""
         vario = Variogram(self.c, self.v, maxlag='median')
 
-        self.assertTrue(vario.pairwise_diffs.ndim == 2)
+        self.assertTrue(vario.pairwise_diffs.ndim == 1)
 
 
 if __name__ == '__main__':  # pragma: no cover


### PR DESCRIPTION
This is the first PR, that actually implements a cross-variogram. With this PR, `Variogram(values=arr)`  the `arr` can be a matrix of shape `(n_samples, n_variables)`. The current state of the implementation only allows for `(n_samples, 2)`, to calculate the cross-variogram of `arr[:,0] ~ arr[:,1]`.
Upcoming versions will add a utility function to calculate cross-variograms for all combinations of multiple variables at once, and plotting thereof. 
The current changes apply to `Variogram` and `DirectionalVariogram`, **not** to `SpaceTimeVariogram`.

<hr/>
@GatorGlaciology, I used the samples of your tutorial Nr. 9: https://github.com/GatorGlaciology/GStatSim/blob/main/demos/9_cokriging_and_cosimulation_MM1.ipynb

I also co-located the surface measurements and applied the transformation, and ended up with this cross-variogram of `Nbed ~ Surface`:

![image](https://user-images.githubusercontent.com/2826034/205295465-77fb5607-69fd-4712-ac32-88358d4523f8.png)

I build the `coords` and `vals` variables in the chunk above inside your demo notebook like:
![image](https://user-images.githubusercontent.com/2826034/205297061-55416709-a340-4b87-a50b-53bdd0479099.png)


@GatorGlaciology, does this make sense to you? 

For reference, I put the primary variogram for `Nbed` only here as well:
![image](https://user-images.githubusercontent.com/2826034/205295655-99553b86-41a9-43c6-8da3-c1e9dd837113.png)

<hr />

Also mentioning @mansourdiene10 to let you know about the current state of cross-variograms.
@digital-idiot, it's been a while, but this might also be interesting for you and should close #41 