### PR TITLE
Cross variogram utility for multiple cross-variograms

### DIFF
--- a/skgstat/__init__.py
+++ b/skgstat/__init__.py
@@ -6,6 +6,7 @@ from .MetricSpace import MetricSpace, MetricSpacePair, ProbabalisticMetricSpace,
 from . import interfaces
 from . import data
 from . import util
+from .util.cross_variogram import cross_variograms
 
 # set some stuff
 from .__version__ import __version__

--- a/skgstat/tests/test_cross_utility.py
+++ b/skgstat/tests/test_cross_utility.py
@@ -1,0 +1,34 @@
+import unittest
+import warnings
+
+import numpy as np
+
+from skgstat.util.cross_variogram import cross_variogram
+
+
+class TestCrossUtility(unittest.TestCase):
+    def setUp(self) -> None:
+        # ignore scipy runtime warnings as for this random data
+        # the covariance may not be positive-semidefinite
+        # this is caused by the multivariate_normal - thus no problem
+        # see here: https://stackoverflow.com/questions/41515522/numpy-positive-semi-definite-warning
+        warnings.simplefilter('ignore', category=RuntimeWarning)
+
+        # set up default values, whenever c and v are not important
+        np.random.seed(42)
+        self.c = np.random.gamma(10, 4, (100, 2))
+        
+        # build the multivariate sample
+        means = [1, 10, 100, 1000]
+        cov = [[1, 0.8, 0.7, 0.6], [0.8, 1, 0.2, 0.2], [0.7, 0.2, 1.0, 0.2], [0.6, 0.2, 0.2, 1.0]]
+        
+        np.random.seed(42)
+        self.v = np.random.multivariate_normal(means, cov, size=100)
+
+    def test_cross_matrix_shape(self):
+        """Test the shape of the cross-variogram matrix for 4 variables"""
+        mat = cross_variogram(self.c, self.v)
+
+        # check shape
+        mat = np.asarray(mat, dtype='object')
+        self.assertTrue(mat.shape, (4, 4))

--- a/skgstat/tests/test_cross_utility.py
+++ b/skgstat/tests/test_cross_utility.py
@@ -4,8 +4,8 @@ import warnings
 import numpy as np
 from numpy.testing import assert_array_almost_equal
 
-from skgstat import Variogram
-from skgstat.util.cross_variogram import cross_variogram
+from skgstat import Variogram, DirectionalVariogram
+from skgstat.util.cross_variogram import cross_variograms
 
 
 class TestCrossUtility(unittest.TestCase):
@@ -29,7 +29,7 @@ class TestCrossUtility(unittest.TestCase):
 
     def test_cross_matrix_shape(self):
         """Test the shape of the cross-variogram matrix for 4 variables"""
-        mat = cross_variogram(self.c, self.v)
+        mat = cross_variograms(self.c, self.v)
 
         # check shape
         mat = np.asarray(mat, dtype='object')
@@ -38,7 +38,7 @@ class TestCrossUtility(unittest.TestCase):
     def test_cross_matrix_diagonal(self):
         """Test that the primary variograms are correct"""
         # get the cross variogram matrix
-        mat = cross_variogram(self.c, self.v, maxlag='median')
+        mat = cross_variograms(self.c, self.v, maxlag='median')
 
         # calculate the first and third primary variogram
         first = Variogram(self.c, self.v[:, 0], maxlag='median')
@@ -54,7 +54,7 @@ class TestCrossUtility(unittest.TestCase):
 
     def test_check_cross_variogram(self):
         """Test two of the cross-variograms in the matrix"""
-        mat = cross_variogram(self.c, self.v, n_lags=15)
+        mat = cross_variograms(self.c, self.v, n_lags=15)
 
         # calculate two cross-variograms
         first = Variogram(self.c, self.v[:, [1, 3]], n_lags=15)
@@ -67,3 +67,11 @@ class TestCrossUtility(unittest.TestCase):
         # assert second variogram
         assert_array_almost_equal(mat[0][2].experimental, second.experimental, 2)
         assert_array_almost_equal(mat[0][2].bins, second.bins, 1)
+
+    def test_for_directional_variograms(self):
+        """Check that DirectionalVariograms are also calcualted correctly"""
+        mat = cross_variograms(self.c, self.v, azimuth=90)
+
+        mat = np.asarray(mat, dtype='object').flatten()
+
+        self.assertTrue(all([isinstance(v, DirectionalVariogram) for v in mat]))

--- a/skgstat/tests/test_cross_utility.py
+++ b/skgstat/tests/test_cross_utility.py
@@ -51,3 +51,19 @@ class TestCrossUtility(unittest.TestCase):
         # assert thrird empirical variogram
         assert_array_almost_equal(mat[2][2].experimental, third.experimental, 2)
         assert_array_almost_equal(mat[2][2].bins, third.bins, 1)
+
+    def test_check_cross_variogram(self):
+        """Test two of the cross-variograms in the matrix"""
+        mat = cross_variogram(self.c, self.v, n_lags=15)
+
+        # calculate two cross-variograms
+        first = Variogram(self.c, self.v[:, [1, 3]], n_lags=15)
+        second = Variogram(self.c, self.v[:, [0, 2]], n_lags=15)
+
+        # assert first variogram
+        assert_array_almost_equal(mat[1][3].experimental, first.experimental, 2)
+        assert_array_almost_equal(mat[1][3].bins, first.bins, 1)
+
+        # assert second variogram
+        assert_array_almost_equal(mat[0][2].experimental, second.experimental, 2)
+        assert_array_almost_equal(mat[0][2].bins, second.bins, 1)

--- a/skgstat/tests/test_cross_utility.py
+++ b/skgstat/tests/test_cross_utility.py
@@ -2,7 +2,9 @@ import unittest
 import warnings
 
 import numpy as np
+from numpy.testing import assert_array_almost_equal
 
+from skgstat import Variogram
 from skgstat.util.cross_variogram import cross_variogram
 
 
@@ -32,3 +34,20 @@ class TestCrossUtility(unittest.TestCase):
         # check shape
         mat = np.asarray(mat, dtype='object')
         self.assertTrue(mat.shape, (4, 4))
+    
+    def test_cross_matrix_diagonal(self):
+        """Test that the primary variograms are correct"""
+        # get the cross variogram matrix
+        mat = cross_variogram(self.c, self.v, maxlag='median')
+
+        # calculate the first and third primary variogram
+        first = Variogram(self.c, self.v[:, 0], maxlag='median')
+        third = Variogram(self.c, self.v[:, 2], maxlag='median')
+
+        # assert first empirical variogram
+        assert_array_almost_equal(mat[0][0].experimental, first.experimental, 2)
+        assert_array_almost_equal(mat[0][0].bins, first.bins, 1)
+
+        # assert thrird empirical variogram
+        assert_array_almost_equal(mat[2][2].experimental, third.experimental, 2)
+        assert_array_almost_equal(mat[2][2].bins, third.bins, 1)

--- a/skgstat/util/cross_variogram.py
+++ b/skgstat/util/cross_variogram.py
@@ -10,7 +10,7 @@ import numpy as np
 
 from skgstat import Variogram,DirectionalVariogram
 
-def cross_variogram(coordinates: np.ndarray, values: np.ndarray, **kwargs) -> List[List[Variogram]]:
+def cross_variograms(coordinates: np.ndarray, values: np.ndarray, **kwargs) -> List[List[Variogram]]:
     """
     Cross-variogram matrix calculation. Similar to a cross-correlation table.
     For all combinations of ``(n_samples, N)`` given values a

--- a/skgstat/util/cross_variogram.py
+++ b/skgstat/util/cross_variogram.py
@@ -1,0 +1,86 @@
+"""
+Cross-variogram utility function. This module can be used to calcualte
+cross-variograms for more than two variables, by creating a variogram
+for each combination of variables.
+
+"""
+from typing import List
+
+import numpy as np
+
+from skgstat import Variogram,DirectionalVariogram
+
+def cross_variogram(coordinates: np.ndarray, values: np.ndarray, **kwargs) -> List[List[Variogram]]:
+    """
+    Cross-variogram matrix calculation. Similar to a cross-correlation table.
+    For all combinations of ``(n_samples, N)`` given values a
+    :class:`Variogram <skgstat.Variogram>` is calculated using the cross-variogram
+    option between two columns into a ``(N, N)`` matrix.
+    The diagonal of the *'matrix'* holds primary variograms (without cross option)
+    for the respective column.
+    The function accepts all keyword arguments that are also accepted by
+    :class:`Variogram <skgstat.Variogram>` and 
+    :class:`DirectionalVariogram <skgstat.DirectionalVariogram>` and passes them
+    down to the respective function. The directional variogram will be used as
+    base class if any of the specific arguments are present: azimuth, bandwidth
+    or tolerance.
+
+    Parameters
+    ----------
+    coordinates : numpy.ndarray, MetricSpace
+        Array of shape (m, n). Will be used as m observation points of
+        n-dimensions. This variogram can be calculated on 1 - n
+        dimensional coordinates. In case a 1-dimensional array is passed,
+        a second array of same length containing only zeros will be
+        stacked to the passed one.
+        For very large datasets, you can set maxlag to only calculate
+        distances within the maximum lag in a sparse matrix.
+        Alternatively you can supply a MetricSpace (optionally with a
+        `max_dist` set for the same effect). This is useful if you're
+        creating many different variograms for different measured
+        parameters that are all measured at the same set of coordinates,
+        as distances will only be calculated once, instead of once per
+        variogram.
+    values : numpy.ndarray
+        Array of values observed at the given coordinates. The length of
+        the values array has to match the m dimension of the coordinates
+        array. Will be used to calculate the dependent variable of the
+        variogram.
+        If the values are of shape ``(n_samples, 2)``, a cross-variogram
+        will be calculated. This assumes the main variable and the
+        co-variable to be co-located under Markov-model 1 assumptions,
+        meaning the variable need to be conditionally independent.
+
+    """
+    # turn input data to numpy arrays
+    coordinates = np.asarray(coordinates)
+    values = np.asarray(values)
+
+    # check which base-class is needed
+    if any([arg in kwargs for arg in ('azimuth', 'tolerance', 'bandwidth')]):
+        BaseCls = DirectionalVariogram
+    else:
+        BaseCls = Variogram
+
+    # create the output matrix
+    cross_m = []
+
+    # get the number of variables
+    N = values.shape[1]
+
+    for i in range(N):
+        # create a new row
+        cross_row = []
+        for j in range(N):
+            # check if this is a primary variogram
+            if i == j:
+                cross_row.append(BaseCls(coordinates, values[:, i], **kwargs))
+            else:
+                # extract the two datasets
+                cross_row.append(None)
+                pass
+
+        # append
+        cross_m.append(cross_row)
+
+    return cross_m

--- a/skgstat/util/cross_variogram.py
+++ b/skgstat/util/cross_variogram.py
@@ -77,8 +77,10 @@ def cross_variogram(coordinates: np.ndarray, values: np.ndarray, **kwargs) -> Li
                 cross_row.append(BaseCls(coordinates, values[:, i], **kwargs))
             else:
                 # extract the two datasets
-                cross_row.append(None)
-                pass
+                v = values[:, [i, j]]
+
+                # append the cross-variogram
+                cross_row.append(BaseCls(coordinates, v, **kwargs))
 
         # append
         cross_m.append(cross_row)

--- a/skgstat/util/cross_variogram.py
+++ b/skgstat/util/cross_variogram.py
@@ -8,7 +8,8 @@ from typing import List
 
 import numpy as np
 
-from skgstat import Variogram,DirectionalVariogram
+from skgstat.Variogram import Variogram
+from skgstat.DirectionalVariogram import DirectionalVariogram
 
 def cross_variograms(coordinates: np.ndarray, values: np.ndarray, **kwargs) -> List[List[Variogram]]:
     """


### PR DESCRIPTION
The new utility function `skgstat.cross_variograms` takes all arguments that `Variogram` and `DirectionalVariogram` accept.
If `values` is a matrix of shape `(n_samples, N)`, a matrix of `(N, N)` cross-variograms is returned for all combinations of `N` variables. The primary variograms are placed on the diagonal of the 'matrix'.

The function does not support plotting right now, this will come with the next version