### PR TITLE
Mahalanobis fix

### DIFF
--- a/skgstat/MetricSpace.py
+++ b/skgstat/MetricSpace.py
@@ -107,7 +107,10 @@ class MetricSpace(DistanceMethods):
 
         # Check if self.dist_metric is valid
         try:
-            pdist(self.coords[:1, :], metric=self.dist_metric)
+            if self.dist_metric=='mahalanobis':
+                _ = pdist(self.coords[:self.coords.shape[1]+1, :], metric=self.dist_metric)
+            else:
+                pdist(self.coords[:1, :], metric=self.dist_metric)
         except ValueError as e:
             raise e
 


### PR DESCRIPTION
Hi,

We noticed that there was a small problem that prevented us from using the Mahalanobis distance in `Variogram()`.

The Mahalanobis distance can only be calculated if the number of points is greater than the number of dimensions (`m > n+1`). When checking if the chosen distance function is supported, `MetricSpace()` tries to calculate the distance on the first point of the coordinates, which forced `pdist` to throw an Exception if `dist_func="euclidean"`.

This little, non-invasive, fix allows to calculate variograms in the Mahalanobis space using `Variogram()` in spaces of an arbitrary number of dimensions.

Thanks for the library!