### PR TITLE
use nopython=True for models

### DIFF
--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -2556,6 +2556,9 @@ class Variogram(object):
         instance. The n and force parameter control the calaculation,
         refer to the data funciton for more info.
 
+        .. deprecated:: 1.0.10
+            The return value of this function will change with a future release
+
         Parameters
         ----------
         n : integer
@@ -2575,6 +2578,7 @@ class Variogram(object):
         Variogram.data
 
         """
+        warnings.warn('The return value of this function will change in a future release.', FutureWarning)
         lags, data = self.data(n=n, force=force)
 
         return DataFrame({

--- a/skgstat/models.py
+++ b/skgstat/models.py
@@ -19,7 +19,7 @@ def variogram(func):
 
 
 @variogram
-@jit
+@jit(nopython=True)
 def spherical(h, r, c0, b=0):
     r"""Spherical Variogram function
 
@@ -83,7 +83,7 @@ def spherical(h, r, c0, b=0):
 
 
 @variogram
-@jit
+@jit(nopython=True)
 def exponential(h, r, c0, b=0):
     r"""Exponential Variogram function
 
@@ -145,7 +145,7 @@ def exponential(h, r, c0, b=0):
 
 
 @variogram
-@jit
+@jit(nopython=True)
 def gaussian(h, r, c0, b=0):
     r""" Gaussian Variogram function
 
@@ -210,7 +210,7 @@ def gaussian(h, r, c0, b=0):
 
 
 @variogram
-@jit
+@jit(nopython=True)
 def cubic(h, r, c0, b=0):
     r"""Cubic Variogram function
 
@@ -274,7 +274,7 @@ def cubic(h, r, c0, b=0):
 
 
 @variogram
-@jit
+@jit(nopython=True)
 def stable(h, r, c0, s, b=0):
     r"""Stable Variogram function
 


### PR DESCRIPTION
closes #146 

@snowman2, thanks for raising the issue and pointing me on the deprecation. I have a quite tight schedule right now and would just rely on my test suite and hope it does not break any test. This PR forces `nopython=True` for all models, but matern, which was already forced to object-mode. It would be great if you could check if that solves the issue.