### PR TITLE
Performance enhancement Variogram in `_calc_groups()` method (scikit-gstat #145)

### DIFF
--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -1425,7 +1425,7 @@ class Variogram(object):
         # get the groups
         groups = self.lag_groups()
 
-        # yield all groups
+        # yield all groups 
         for i in range(len(self.bins)):
             yield diffs[np.where(groups == i)]
 
@@ -1822,12 +1822,10 @@ class Variogram(object):
         # get the bin edges and distances
         bin_edges = self.bins
         d = self.distance
-
-        # -1 is the group fir distances outside maxlag
-        self._groups = np.ones(len(d), dtype=int) * -1
-
-        for i, bounds in enumerate(zip([0] + list(bin_edges), bin_edges)):
-            self._groups[np.where((d >= bounds[0]) & (d < bounds[1]))] = i
+        
+        # -1 is the group for distances outside maxlag
+        bins = np.digitize(d, bin_edges)
+        self._groups = np.where(bins == self.n_lags, -1, bins) 
 
     def clone(self):
         """Deep copy of self


### PR DESCRIPTION
I made a start here. Some questions: 

The `_group` names should be `1` up to `len(bin_edges) - 1`, and where group `len(bin_edges)` should be `-1`, as this last group will be leftout of the variogram? If that is correct, I need to figure out how this can be done efficiently.

I ran `pytest` but I got a lot of failures which say: "ValueError: `ydata` must not be empty!". What does this mean?
 