### PR TITLE
Check code and docs spelling via `pre-commit`

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,15 @@
+name: Linting and formatting (pre-commit)
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+        # Fix common spelling mistakes
+        - repo: https://github.com/codespell-project/codespell
+          rev: v2.2.1
+          hooks:
+                - id: codespell
+                  args: [
+#                    '--ignore-words-list', 'nd,alos,inout',
+#                    '--ignore-regex', '\bhist\b',
+                    '--'
+                  ]
+                  types_or: [python, rst, markdown]
+                  files: ^(skgstat|docs|tutorials)/


### PR DESCRIPTION
Hey @mmaelicke,

I've been noticing typos here and there in the package. In other projects, I also had a hard time with those for a while until I started using `pre-commit`/`codespell` (and other hooks).

I ran it out of curiosity on `skgstat`, and it's a pretty long output! Opening this temporary PR for you to see the output of it in CI: https://github.com/mmaelicke/scikit-gstat/actions/runs/5945047993/job/16123425002?pr=163

There's also a ton of other useful things that can be done in `pre-commit`, I don't how familiar you are with it. I had trouble starting a couple years ago, and now I can't code (in a repo) without, it saves so much time down the line!  