### PR TITLE
Update test_spacetimevariogram.py

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,10 +7,10 @@ on:
 jobs:
   test:
    name: Run Unittest
-   runs-on: ubuntu-20.04
+   runs-on: ubuntu-22.04
    strategy:
     matrix:
-      python: ['3.9', '3.10', '3.11']
+      python: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
    steps:
       - name: Checkout
@@ -45,7 +45,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@master
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install SciKit-GStat
         run: |
           pip3 install -r requirements.txt
@@ -80,13 +80,13 @@ jobs:
 
   release:
     name: Create Github release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: test
     if: startsWith(github.event.ref, 'refs/tags/v') && endsWith(github.event.ref, '.0')
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@master
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -96,14 +96,14 @@ jobs:
 
   publish:
     name: Publish to PyPi
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: test
     if: startsWith(github.event.ref, 'refs/tags/v')
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@master
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@master
       with:
         python-version: '3.x'
     - name: Install dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+setuptools
 scipy
 numpy
 pandas

--- a/requirements.unittest.3.13.txt
+++ b/requirements.unittest.3.13.txt
@@ -1,0 +1,6 @@
+pytest
+pytest-cov
+pytest-depends
+pykrige
+gstools>=1.3
+plotly

--- a/skgstat/tests/test_spacetimevariogram.py
+++ b/skgstat/tests/test_spacetimevariogram.py
@@ -105,12 +105,6 @@ class TestSpaceTimeVariogramArgumets(unittest.TestCase):
                 str(e), 'For now only str arguments are supported.'
             )
 
-    def test_tdist_func(self):
-        V = SpaceTimeVariogram(self.c, self.v, tdist_func='jaccard')
-
-        # with jaccard, all should disagree
-        self.assertTrue(all([_ == 1. for _ in V.tdistance]))
-
     def test_tdist_func_raises_ValueError(self):
         with self.assertRaises(ValueError) as e:
             V = SpaceTimeVariogram(self.c, self.v)


### PR DESCRIPTION
Removing the unittest that was misusing the jaccard distance to calculate distances in time for spatio-temporal variograms.

Also updated the CI to the latest python versions
This should also close #194 