### PR TITLE
fix: custom bounds and p0 will be ignored if fitting is triggered by property getters.

### DIFF
--- a/skgstat/Variogram.py
+++ b/skgstat/Variogram.py
@@ -389,9 +389,7 @@ class Variogram(object):
 
         # do the preprocessing and fitting upon initialization
         # Note that fit() calls preprocessing
-        fit_bounds = self._kwargs.get('fit_bounds') # returns None if empty
-        fit_p0 = self._kwargs.get('fit_p0')
-        self.fit(force=True, bounds=fit_bounds, p0=fit_p0)
+        self.fit(force=True)
 
         # finally check if any of the uncertainty propagation kwargs are set
         self._experimental_conf_interval = None
@@ -1622,6 +1620,12 @@ class Variogram(object):
         scipy.optimize.least_squares
 
         """
+        # get `bounds` and `p0` from `self._kwargs`, still `None` if not set
+        if bounds is None:
+            bounds = self._kwargs.get('fit_bounds') # returns None if empty
+        if p0 is None:
+            p0 = self._kwargs.get('fit_p0')
+
         # store the old cof
         if self.cof is None:
             old_params = {}


### PR DESCRIPTION
In the current code, the custom `bounds` and `p0` stored in `self._kwargs` are only used when `self.fit()` is called in `__init__()`:

https://github.com/mmaelicke/scikit-gstat/blob/46bc79e24add846158a9e9b3803ba014d708d939/skgstat/Variogram.py#L392-L394

But not in some property getters, for example in `transform()`:

https://github.com/mmaelicke/scikit-gstat/blob/46bc79e24add846158a9e9b3803ba014d708d939/skgstat/Variogram.py#L1809-L1810

or in `describe()`:

https://github.com/mmaelicke/scikit-gstat/blob/46bc79e24add846158a9e9b3803ba014d708d939/skgstat/Variogram.py#L2611-L2612

etc.

Considering this, I suggest getting custom `bounds` and `p0` within `fit()`.